### PR TITLE
Upgraded dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,18 +4,18 @@ import ReleaseTransformations._
 import sbtcrossproject.{CrossType, crossProject}
 
 lazy val scalaVersions: Map[String, String] =
-  Map("2.11" -> "2.11.12", "2.12" -> "2.12.6")
+  Map("2.11" -> "2.11.12", "2.12" -> "2.12.8")
 
 lazy val scalaCheckVersion = "1.14.0"
-lazy val scalaTestVersion = "3.0.6-SNAP1"
+lazy val scalaTestVersion = "3.0.6-SNAP6"
 lazy val shapelessVersion = "2.3.3"
-lazy val disciplineVersion = "0.10.0"
-lazy val machinistVersion = "0.6.4"
-lazy val algebraVersion = "1.0.0"
+lazy val disciplineVersion = "0.11.0"
+lazy val machinistVersion = "0.6.6"
+lazy val algebraVersion = "1.0.1"
 
-lazy val apfloatVersion = "1.8.2"
+lazy val apfloatVersion = "1.8.3"
 lazy val jscienceVersion = "4.3.1"
-lazy val apacheCommonsMath3Version = "3.4.1"
+lazy val apacheCommonsMath3Version = "3.6.1"
 
 
 // Projects

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.5
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,22 +1,17 @@
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
-addSbtPlugin("com.jsuereth"        % "sbt-pgp"               % "1.1.1")
-addSbtPlugin("com.github.gseitz"   % "sbt-release"           % "1.0.8")
+addSbtPlugin("com.jsuereth"        % "sbt-pgp"               % "1.1.2")
+addSbtPlugin("com.github.gseitz"   % "sbt-release"           % "1.0.9")
 addSbtPlugin("com.eed3si9n"        % "sbt-unidoc"            % "0.4.2")
 addSbtPlugin("com.eed3si9n"        % "sbt-buildinfo"         % "0.9.0")
 addSbtPlugin("pl.project13.scala"  % "sbt-jmh"               % "0.3.4")
 addSbtPlugin("org.scoverage"       % "sbt-scoverage"         % "1.5.1")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"    % "sbt-git"               % "1.0.0")
-addSbtPlugin("org.xerial.sbt"      % "sbt-sonatype"          % "2.3")
-addSbtPlugin("org.scala-js"        % "sbt-scalajs"           % "0.6.23")
-addSbtPlugin("org.tpolecat"        % "tut-plugin"            % "0.6.3")
-addSbtPlugin("net.virtual-void"    % "sbt-dependency-graph"  % "0.9.0")
-addSbtPlugin("org.portable-scala"  % "sbt-scalajs-crossproject" % "0.5.0")
+addSbtPlugin("org.xerial.sbt"      % "sbt-sonatype"          % "2.4")
+addSbtPlugin("org.scala-js"        % "sbt-scalajs"           % "0.6.26")
+addSbtPlugin("org.tpolecat"        % "tut-plugin"            % "0.6.10")
+addSbtPlugin("net.virtual-void"    % "sbt-dependency-graph"  % "0.9.2")
+addSbtPlugin("org.portable-scala"  % "sbt-scalajs-crossproject" % "0.6.0")
 addSbtPlugin("com.47deg"           % "sbt-microsites"        % "0.7.21")
-libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.12"
-
-
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
-addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"  % "0.4.1")
+libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.25"


### PR DESCRIPTION
- Scala 2.12.8
- ScalaTest 3.0.6-SNAP6
- Discipline 0.11.0
- Machinist 0.6.6
- Algebra 1.0.1
- Apfloat 1.8.3
- Apache Commons Math 3.6.1
- SBT 1.2.8
- sbt-pgp 1.1.2
- sbt-release 1.0.9
- sbt-sonatype 2.4
- scala-js 0.6.26
- tut 0.6.10
- sbt-dependency-graph 0.9.2
- sbt-scalajs-crossproject 0.6.0
- slf4j 1.7.25