### PR TITLE
incorrect link to microsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@
 Spire is a numeric library for Scala which is intended to be generic, fast,
 and precise.
 
-See the [companion microsite](https://non.github.io/spire/)
+See the [companion microsite](https://typelevel.org/spire/)


### PR DESCRIPTION
link was headed to non.github.io instead of typelevel.com