### PR TITLE
Adopt the Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+People are expected to follow the [Scala Code of Conduct](https://www.scala-lang.org/conduct/)
+when discussing Spire on the Github page, in Gitter, the IRC channel,
+mailing list, and other official venues.
+
+Concerns or issues can be sent to any of Spire's maintainers, or to the
+[Typelevel](http://typelevel.org/about.html) organization.

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -50,7 +50,7 @@ merging pull requests, and for helping to guide the direction of Spire:
  * Rüdiger Klaehn (*rklaehn@gmail.com*)
  * Denis Rosset (*physics@denisrosset.com*)
 
-People are expected to follow the [Typelevel Code of Conduct](http://typelevel.org/conduct.html)
+People are expected to follow the [Scala Code of Conduct](https://www.scala-lang.org/conduct/)
 when discussing Spire on the Github page, in Gitter, the IRC channel,
 mailing list, and other official venues.
 


### PR DESCRIPTION
Typelevel is about to announce that it is moving to the Scala Code of Conduct for all participating projects. The Scala Code of Conduct was by developed by the Scala Center with input from Typelevel and improves on the Typelevel code of conduct in a number of ways and can be thought of as the "Typelevel code of conduct v. 2.0". We want people participating in projects and activities right across the Scala ecosystem to be able to expect a uniform standard of good behavior, and coordinating on a shared code of conduct is an important step in that direction.