### PR TITLE
Remove scala-collection-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -284,8 +284,7 @@ lazy val buildSettings = Seq(
 
 lazy val commonDeps = Seq(libraryDependencies ++= Seq(
   "org.typelevel" %%% "machinist" % machinistVersion,
-  "org.typelevel" %%% "algebra" % algebraVersion,
-  "org.scala-lang.modules" %%% "scala-collection-compat" % "0.3.0"))
+  "org.typelevel" %%% "algebra" % algebraVersion))
 
 lazy val commonSettings = Seq(
   scalacOptions ++= commonScalacOptions.value.diff(Seq(

--- a/compat/src/main/scala-2.13/package.scala
+++ b/compat/src/main/scala-2.13/package.scala
@@ -17,6 +17,8 @@ import scala.reflect.ClassTag
 
   type IterableLike[A, C] = scala.collection.IterableOps[A, Iterable, C]
 
+  private[spire] type IterableOnce[+X] = scala.collection.IterableOnce[X]
+
   private[spire] type Factory[-A, +C] = scala.collection.Factory[A, C]
 
   private[spire] type FactoryCompatOps

--- a/compat/src/main/scala-2.13/package.scala
+++ b/compat/src/main/scala-2.13/package.scala
@@ -16,4 +16,8 @@ import scala.reflect.ClassTag
   type SeqLike[A, C] = scala.collection.SeqOps[A, Seq, C]
 
   type IterableLike[A, C] = scala.collection.IterableOps[A, Iterable, C]
+
+  private[spire] type Factory[-A, +C] = scala.collection.Factory[A, C]
+
+  private[spire] type FactoryCompatOps
 }

--- a/compat/src/main/scala-pre-2.13/package.scala
+++ b/compat/src/main/scala-pre-2.13/package.scala
@@ -17,6 +17,8 @@ import scala.reflect.ClassTag
 
   type IterableLike[A, C] = scala.collection.IterableLike[A, C]
 
+  private[spire] type IterableOnce[+X] = scala.collection.TraversableOnce[X]
+
   private[spire] type Factory[-A, +C] = CanBuildFrom[Nothing, A, C]
 
   private[spire] implicit class FactoryCompatOps[-A, +C](private val factory: Factory[A, C]) {

--- a/compat/src/main/scala-pre-2.13/package.scala
+++ b/compat/src/main/scala-pre-2.13/package.scala
@@ -1,7 +1,8 @@
 package spire
 package object scalacompat {
 
-import scala.collection.mutable.ArrayBuilder
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.{ArrayBuilder, Builder}
 import scala.collection.parallel.ParSeq
 import scala.reflect.ClassTag
 
@@ -15,4 +16,12 @@ import scala.reflect.ClassTag
   type SeqLike[A, C] = scala.collection.SeqLike[A, C]
 
   type IterableLike[A, C] = scala.collection.IterableLike[A, C]
+
+  private[spire] type Factory[-A, +C] = CanBuildFrom[Nothing, A, C]
+
+  private[spire] implicit class FactoryCompatOps[-A, +C](private val factory: Factory[A, C]) {
+    def fromSpecific(it: TraversableOnce[A]): C = (factory() ++= it).result()
+
+    def newBuilder: Builder[A, C] = factory()
+  }
 }

--- a/core/src/main/scala/spire/algebra/CoordinateSpace.scala
+++ b/core/src/main/scala/spire/algebra/CoordinateSpace.scala
@@ -3,8 +3,7 @@ package algebra
 
 import spire.std._
 
-import scala.collection.compat._
-import spire.scalacompat.SeqLike
+import spire.scalacompat.{Factory, SeqLike}
 
 trait CoordinateSpace[V, @sp(Float, Double) F] extends Any with InnerProductSpace[V, F] {
   def dimensions: Int

--- a/core/src/main/scala/spire/algebra/NormedVectorSpace.scala
+++ b/core/src/main/scala/spire/algebra/NormedVectorSpace.scala
@@ -3,8 +3,7 @@ package algebra
 
 import spire.std._
 
-import scala.collection.compat._
-import spire.scalacompat.SeqLike
+import spire.scalacompat.{Factory, SeqLike}
 
 /**
  * A normed vector space is a vector space equipped with a function

--- a/core/src/main/scala/spire/optional/mapIntIntPermutation.scala
+++ b/core/src/main/scala/spire/optional/mapIntIntPermutation.scala
@@ -1,8 +1,7 @@
 package spire
 package optional
 
-import scala.collection.compat._
-import spire.scalacompat.SeqLike
+import spire.scalacompat.{Factory, FactoryCompatOps, SeqLike}
 
 import spire.algebra.{Action, Group}
 import spire.algebra.partial.PartialAction

--- a/core/src/main/scala/spire/optional/partialIterable.scala
+++ b/core/src/main/scala/spire/optional/partialIterable.scala
@@ -1,8 +1,7 @@
 package spire
 package optional
 
-import scala.collection.compat._
-import spire.scalacompat.IterableLike
+import spire.scalacompat.{Factory, FactoryCompatOps, IterableLike}
 
 import spire.algebra.{Semigroup, Group}
 import spire.algebra.partial.{Semigroupoid, Groupoid}

--- a/core/src/main/scala/spire/random/Dist.scala
+++ b/core/src/main/scala/spire/random/Dist.scala
@@ -4,8 +4,8 @@ package random
 import spire.algebra._
 import spire.syntax.all._
 import spire.math.{Complex, Interval, Natural, Rational, SafeLong, UByte, UShort, UInt, ULong}
+import spire.scalacompat.{Factory, FactoryCompatOps}
 
-import scala.collection.compat._
 import scala.collection.mutable.ArrayBuffer
 
 trait Dist[@sp A] extends Any { self =>

--- a/core/src/main/scala/spire/random/Random.scala
+++ b/core/src/main/scala/spire/random/Random.scala
@@ -1,7 +1,7 @@
 package spire
 package random
 
-import scala.collection.compat._
+import spire.scalacompat.{Factory, FactoryCompatOps}
 
 sealed trait Op[+A] {
 

--- a/core/src/main/scala/spire/std/iterable.scala
+++ b/core/src/main/scala/spire/std/iterable.scala
@@ -1,8 +1,7 @@
 package spire
 package std
 
-import scala.collection.compat._
-import spire.scalacompat.IterableLike
+import spire.scalacompat.{Factory, FactoryCompatOps, IterableLike}
 
 import spire.algebra.Monoid
 

--- a/core/src/main/scala/spire/std/seq.scala
+++ b/core/src/main/scala/spire/std/seq.scala
@@ -1,8 +1,7 @@
 package spire
 package std
 
-import scala.collection.compat._
-import spire.scalacompat.SeqLike
+import spire.scalacompat.{Factory, FactoryCompatOps, SeqLike}
 import scala.collection.mutable.Builder
 
 import spire.algebra._

--- a/core/src/main/scala/spire/syntax/std/Ops.scala
+++ b/core/src/main/scala/spire/syntax/std/Ops.scala
@@ -2,9 +2,9 @@ package spire
 package syntax
 package std
 
-import scala.collection.compat._
 import spire.algebra.{AdditiveMonoid, Field, Monoid, MultiplicativeMonoid, NRoot, Order, PartialOrder, Signed}
 import spire.math.{Natural, Number, QuickSort, SafeLong, Searching, ULong}
+import spire.scalacompat.{Factory, FactoryCompatOps}
 import spire.syntax.cfor._
 import spire.syntax.monoid._
 import spire.syntax.field._

--- a/examples/src/main/scala/spire/example/DataSets.scala
+++ b/examples/src/main/scala/spire/example/DataSets.scala
@@ -5,7 +5,7 @@ import spire.algebra._
 import spire.math.Rational
 import spire.implicits._
 
-import spire.scalacompat.BuilderCompat
+import spire.scalacompat.{BuilderCompat, Factory, FactoryCompatOps, IterableOnce}
 
 import scala.collection.mutable.{ Builder, ListBuffer }
 

--- a/examples/src/main/scala/spire/example/DataSets.scala
+++ b/examples/src/main/scala/spire/example/DataSets.scala
@@ -5,7 +5,6 @@ import spire.algebra._
 import spire.math.Rational
 import spire.implicits._
 
-import scala.collection.compat._
 import spire.scalacompat.BuilderCompat
 
 import scala.collection.mutable.{ Builder, ListBuffer }

--- a/examples/src/main/scala/spire/example/kmeans.scala
+++ b/examples/src/main/scala/spire/example/kmeans.scala
@@ -4,7 +4,6 @@ package example
 import spire.algebra._
 import spire.implicits._
 
-import scala.collection.compat._
 import scala.util.Random.{ nextInt, nextDouble, nextGaussian }
 
 /**

--- a/examples/src/main/scala/spire/example/kmeans.scala
+++ b/examples/src/main/scala/spire/example/kmeans.scala
@@ -3,6 +3,7 @@ package example
 
 import spire.algebra._
 import spire.implicits._
+import spire.scalacompat.{Factory, FactoryCompatOps}
 
 import scala.util.Random.{ nextInt, nextDouble, nextGaussian }
 


### PR DESCRIPTION
The 1.0.0 release of scala-collection-compat is broken and we're waiting on an incompatible 2.0.0, but it's barely used here, and can be completely replaced with two type aliases and one implicit class (and the implicit class is only needed pre-2.13).

This change is fully compatible with previous releases and avoids forcing a transitive dependency on users.

r? @larsrh 