### PR TITLE
Replace Heyting by DeMorgan for Trilean

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,6 +171,7 @@ lazy val laws = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
   .settings(spireSettings:_*)
   .settings(libraryDependencies ++= Seq(
     "org.typelevel" %%% "discipline-scalatest" % disciplineScalaTestVersion,
+    "org.typelevel" %%% "algebra-laws" % algebraVersion,
     "org.scalacheck" %%% "scalacheck" % scalaCheckVersion
   ))
   .jvmSettings(commonJvmSettings:_*)

--- a/core/src/main/scala/spire/algebra/lattice/package.scala
+++ b/core/src/main/scala/spire/algebra/lattice/package.scala
@@ -2,8 +2,14 @@ package spire
 package algebra
 
 package object lattice {
+  type Logic[A] = _root_.algebra.lattice.Logic[A]
+  val Logic = _root_.algebra.lattice.Logic
+
   type Heyting[A] = _root_.algebra.lattice.Heyting[A]
   val Heyting = _root_.algebra.lattice.Heyting
+
+  type DeMorgan[A] = _root_.algebra.lattice.DeMorgan[A]
+  val DeMorgan = _root_.algebra.lattice.DeMorgan
 
   type Lattice[A] = _root_.algebra.lattice.Lattice[A]
   val Lattice = _root_.algebra.lattice.Lattice

--- a/core/src/main/scala/spire/math/Trilean.scala
+++ b/core/src/main/scala/spire/math/Trilean.scala
@@ -1,7 +1,8 @@
 package spire
 package math
 
-import spire.algebra.lattice.Heyting
+import spire.algebra.Eq
+import algebra.lattice.DeMorgan
 
 /**
  * Implementation of three-valued logic.
@@ -162,13 +163,16 @@ object Trilean {
     }
 
   implicit val algebra = new TrileanAlgebra
+
+  implicit val trileanEq = new Eq[Trilean] {
+    def eqv(x: Trilean, y: Trilean): Boolean = x.value == y.value
+  }
 }
 
-class TrileanAlgebra extends Heyting[Trilean] {
+class TrileanAlgebra extends DeMorgan[Trilean] {
   def one: Trilean = Trilean.True
   def zero: Trilean = Trilean.False
-  def complement(a: Trilean): Trilean = !a
+  def not(a: Trilean): Trilean = !a
   def and(a: Trilean, b: Trilean): Trilean = a & b
   def or(a: Trilean, b: Trilean): Trilean = a | b
-  def imp(a: Trilean, b: Trilean): Trilean = a imp b
 }

--- a/core/src/main/scala/spire/syntax/Ops.scala
+++ b/core/src/main/scala/spire/syntax/Ops.scala
@@ -381,6 +381,16 @@ final class HeytingOps[A: Heyting](lhs:A) {
   def |(rhs: Int)(implicit ev1: Ring[A]): A = macro Ops.binopWithLift[Int, Ring[A], A]
 }
 
+final class LogicOps[A](lhs:A)(implicit logic: Logic[A]) {
+  def unary_!(): A = logic.not(lhs)
+
+  def &(rhs: A): A = macro Ops.binop[A, A]
+  def |(rhs: A): A = macro Ops.binop[A, A]
+
+  def &(rhs: Int)(implicit ev1: Ring[A]): A = macro Ops.binopWithLift[Int, Ring[A], A]
+  def |(rhs: Int)(implicit ev1: Ring[A]): A = macro Ops.binopWithLift[Int, Ring[A], A]
+}
+
 final class BoolOps[A: Bool](lhs:A) {
   def ^(rhs: A): A = macro Ops.binop[A, A]
   def nand(rhs: A): A = macro Ops.binop[A, A]

--- a/core/src/main/scala/spire/syntax/Syntax.scala
+++ b/core/src/main/scala/spire/syntax/Syntax.scala
@@ -173,6 +173,10 @@ trait HeytingSyntax {
   implicit def heytingOps[A: Heyting](a: A): HeytingOps[A] = new HeytingOps(a)
 }
 
+trait LogicSyntax {
+  implicit def logicOps[A: Logic](a: A): LogicOps[A] = new LogicOps(a)
+}
+
 trait BoolSyntax extends HeytingSyntax {
   implicit def boolOps[A: Bool](a: A): BoolOps[A] = new BoolOps(a)
 }
@@ -299,6 +303,7 @@ trait AllSyntax extends
     InnerProductSpaceSyntax with
     CoordinateSpaceSyntax with
     LatticeSyntax with
+    LogicSyntax with
     HeytingSyntax with
     BoolSyntax with
     BitStringSyntax with

--- a/core/src/main/scala/spire/syntax/package.scala
+++ b/core/src/main/scala/spire/syntax/package.scala
@@ -50,6 +50,7 @@ package object syntax {
 
   object lattice extends LatticeSyntax
   object heyting extends HeytingSyntax
+  object logic extends LogicSyntax
   object bool extends BoolSyntax
 
   object bitString extends BitStringSyntax

--- a/laws/src/main/scala/spire/laws/LogicLaws.scala
+++ b/laws/src/main/scala/spire/laws/LogicLaws.scala
@@ -2,10 +2,9 @@ package spire
 package laws
 
 import spire.algebra.{Eq, Bool}
-import spire.algebra.lattice.{DeMorgan, Heyting}
+import spire.algebra.lattice.Heyting
 import spire.syntax.eq._
 import spire.syntax.bool._
-import spire.syntax.logic._
 
 import org.typelevel.discipline.Laws
 
@@ -82,35 +81,6 @@ trait LogicLaws[A] extends Laws {
       },
 
       "(0 -> x) = 1" -> forAllSafe { (x: A) => (A.zero imp x) === A.one }
-    )
-
-  def deMorgan(implicit A: DeMorgan[A]) =
-    new DefaultRuleSet(
-      name = "deMorgan",
-      parent = None,
-      "associative" -> forAllSafe { (x: A, y: A, z: A) =>
-        ((x & y) & z) === (x & (y & z)) && ((x | y) | z) === (x | (y | z))
-      },
-
-      "commutative" -> forAllSafe { (x: A, y: A) =>
-        (x & y) === (y & x) && (x | y) === (y | x)
-      },
-
-      "absorption" -> forAllSafe { (x: A, y: A) =>
-        (x & (x | y)) === x && (x | (x & y)) === x
-      },
-
-      "identity" -> forAllSafe { (x: A) =>
-        (x & A.one) === x && (x | A.zero) === x
-      },
-
-      "distributive" -> forAllSafe { (x: A, y: A, z: A) =>
-        (x & (y | z)) === ((x & y) | (x & z)) && (x | (y & z)) === ((x | y) & (x | z))
-      },
-
-      "involutive" -> forAllSafe { (x: A) => (!(!x)) === x },
-
-      "¬(x∧y) = (¬x∨¬y)" -> forAllSafe { (x: A, y: A) => !(x&y) === ((!x)|(!y)) },
     )
 
   def bool(implicit A: Bool[A]) =

--- a/laws/src/main/scala/spire/laws/LogicLaws.scala
+++ b/laws/src/main/scala/spire/laws/LogicLaws.scala
@@ -2,9 +2,10 @@ package spire
 package laws
 
 import spire.algebra.{Eq, Bool}
-import spire.algebra.lattice.Heyting
+import spire.algebra.lattice.{DeMorgan, Heyting}
 import spire.syntax.eq._
 import spire.syntax.bool._
+import spire.syntax.logic._
 
 import org.typelevel.discipline.Laws
 
@@ -81,6 +82,35 @@ trait LogicLaws[A] extends Laws {
       },
 
       "(0 -> x) = 1" -> forAllSafe { (x: A) => (A.zero imp x) === A.one }
+    )
+
+  def deMorgan(implicit A: DeMorgan[A]) =
+    new DefaultRuleSet(
+      name = "deMorgan",
+      parent = None,
+      "associative" -> forAllSafe { (x: A, y: A, z: A) =>
+        ((x & y) & z) === (x & (y & z)) && ((x | y) | z) === (x | (y | z))
+      },
+
+      "commutative" -> forAllSafe { (x: A, y: A) =>
+        (x & y) === (y & x) && (x | y) === (y | x)
+      },
+
+      "absorption" -> forAllSafe { (x: A, y: A) =>
+        (x & (x | y)) === x && (x | (x & y)) === x
+      },
+
+      "identity" -> forAllSafe { (x: A) =>
+        (x & A.one) === x && (x | A.zero) === x
+      },
+
+      "distributive" -> forAllSafe { (x: A, y: A, z: A) =>
+        (x & (y | z)) === ((x & y) | (x & z)) && (x | (y & z)) === ((x | y) & (x | z))
+      },
+
+      "involutive" -> forAllSafe { (x: A) => (!(!x)) === x },
+
+      "¬(x∧y) = (¬x∨¬y)" -> forAllSafe { (x: A, y: A) => !(x&y) === ((!x)|(!y)) },
     )
 
   def bool(implicit A: Bool[A]) =

--- a/laws/src/main/scala/spire/laws/package.scala
+++ b/laws/src/main/scala/spire/laws/package.scala
@@ -9,6 +9,9 @@ import org.typelevel.discipline.Predicate
 
 package object laws {
 
+  type DeMorganLaws[A] = _root_.algebra.laws.DeMorganLaws[A]
+  val DeMorganLaws = _root_.algebra.laws.DeMorganLaws
+
   implicit def PredicateFromMonoid[A: Eq](implicit A: AdditiveMonoid[A]): Predicate[A] = new Predicate[A] {
     def apply(a: A) = a =!= A.zero
   }

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -192,7 +192,7 @@ class LawTests extends AnyFunSuite with FunSuiteDiscipline with Checkers {
 
   checkAll("Bool[Boolean]", LogicLaws[Boolean].bool)
   checkAll("Bool[Int]", LogicLaws[Int].bool)
-  checkAll("Heyting[Trilean]", LogicLaws[Int].heyting)
+  checkAll("DeMorgan[Trilean]", LogicLaws[Trilean].deMorgan)
 
   object intMinMaxLattice extends MinMaxLattice[Int] with BoundedLattice[Int] with spire.std.IntOrder {
     def zero = Int.MinValue

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -192,7 +192,8 @@ class LawTests extends AnyFunSuite with FunSuiteDiscipline with Checkers {
 
   checkAll("Bool[Boolean]", LogicLaws[Boolean].bool)
   checkAll("Bool[Int]", LogicLaws[Int].bool)
-  checkAll("DeMorgan[Trilean]", LogicLaws[Trilean].deMorgan)
+  implicit val latticeLawsTrilean = _root_.algebra.laws.LatticeLaws[Trilean]
+  checkAll("DeMorgan[Trilean]", DeMorganLaws[Trilean].deMorgan)
 
   object intMinMaxLattice extends MinMaxLattice[Int] with BoundedLattice[Int] with spire.std.IntOrder {
     def zero = Int.MinValue


### PR DESCRIPTION
Trilean is not a valid `Heyting` as it does not satisfy the
non-contradiction law:
```
and(not(a), a) == Trilean.False
```

This commit removes the `Heyting` instance and replaces it by a
`DeMorgan` instance.