### PR TITLE
Remove unicode identifiers

### DIFF
--- a/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/RationalBenchmarks.scala
@@ -21,14 +21,14 @@ object RationalUtil {
     classify(a) + "_" + classify(b) + "_" + classify(a_op_b)
 
   def check(cases: Map[String, (Rational, Rational)]): Unit = {
-    for ((kind, (a, b)) ← cases) {
+    for ((kind, (a, b)) <- cases) {
       val c = classify(a, b)
       require(kind.startsWith(c), s"Unexpected class $c for case $kind")
     }
   }
 
-  def check(cases: Map[String, (Rational, Rational)], op: (Rational, Rational) ⇒ Rational): Unit = {
-    for ((kind, (a, b)) ← cases) {
+  def check(cases: Map[String, (Rational, Rational)], op: (Rational, Rational) => Rational): Unit = {
+    for ((kind, (a, b)) <- cases) {
       val c = classify(a, b, op(a, b))
       require(kind.startsWith(c), s"Unexpected class $c for case $kind")
     }
@@ -41,11 +41,11 @@ object RationalUtil {
 class RationalMultiplyDivideBenchmark {
 
   val pairs = Map(
-    "li_li_li" → ((Rational(12345), Rational(67890))),
-    "bi_bi_bi" → ((Rational(12345) + Long.MaxValue, Rational(67890) + Long.MaxValue)),
-    "lf_lf_lf" → ((Rational(12345, 67891), Rational(67890, 12347))),
-    "lf_lf_bf" → ((Rational(Long.MaxValue, Int.MaxValue - 1), Rational(Long.MaxValue, Int.MaxValue - 3))),
-    "bf_bf_bf" → ((Rational(Long.MaxValue) + Rational(1, 3), Rational(Long.MaxValue) + Rational(1, 5))))
+    "li_li_li" -> ((Rational(12345), Rational(67890))),
+    "bi_bi_bi" -> ((Rational(12345) + Long.MaxValue, Rational(67890) + Long.MaxValue)),
+    "lf_lf_lf" -> ((Rational(12345, 67891), Rational(67890, 12347))),
+    "lf_lf_bf" -> ((Rational(Long.MaxValue, Int.MaxValue - 1), Rational(Long.MaxValue, Int.MaxValue - 3))),
+    "bf_bf_bf" -> ((Rational(Long.MaxValue) + Rational(1, 3), Rational(Long.MaxValue) + Rational(1, 5))))
   check(pairs, _ * _)
   check(pairs, _ / _.inverse)
 
@@ -83,11 +83,11 @@ class RationalMultiplyDivideBenchmark {
 class RationalAddSubtractBenchmark {
 
   val pairs = Map(
-    "li_li_li" → ((Rational(12345), Rational(67890))),
-    "bi_bi_bi" → ((Rational(12345) + Long.MaxValue, Rational(67890) + Long.MaxValue)),
-    "lf_lf_lf" →  ((Rational(12345,67891), Rational(67890,12347))),
-    "lf_lf_bf" → ((Rational(Long.MaxValue,Int.MaxValue - 1), Rational(Long.MaxValue,Int.MaxValue - 3))),
-    "bf_bf_bf" → ((Rational(Long.MaxValue) + Rational(1,3), Rational(Long.MaxValue) + Rational(1,5))))
+    "li_li_li" -> ((Rational(12345), Rational(67890))),
+    "bi_bi_bi" -> ((Rational(12345) + Long.MaxValue, Rational(67890) + Long.MaxValue)),
+    "lf_lf_lf" ->  ((Rational(12345,67891), Rational(67890,12347))),
+    "lf_lf_bf" -> ((Rational(Long.MaxValue,Int.MaxValue - 1), Rational(Long.MaxValue,Int.MaxValue - 3))),
+    "bf_bf_bf" -> ((Rational(Long.MaxValue) + Rational(1,3), Rational(Long.MaxValue) + Rational(1,5))))
   check(pairs, _ + _)
   check(pairs, _ - -_)
 
@@ -121,10 +121,10 @@ class RationalAddSubtractBenchmark {
 @State(Scope.Thread)
 class RationalCompareBenchmark {
   val pairs = Map(
-    "li_li" → ((Rational(12345), Rational(67890))),
-    "lf_lf" →  ((Rational(12345,67891), Rational(67890,12347))),
-    "lf_lf_intermediateBig" → ((Rational(Long.MaxValue,Int.MaxValue - 1), Rational(Long.MaxValue,Int.MaxValue - 3))),
-    "bf_bf" → ((Rational(Long.MaxValue) + Rational(1,3), Rational(Long.MaxValue) + Rational(1,5))))
+    "li_li" -> ((Rational(12345), Rational(67890))),
+    "lf_lf" ->  ((Rational(12345,67891), Rational(67890,12347))),
+    "lf_lf_intermediateBig" -> ((Rational(Long.MaxValue,Int.MaxValue - 1), Rational(Long.MaxValue,Int.MaxValue - 3))),
+    "bf_bf" -> ((Rational(Long.MaxValue) + Rational(1,3), Rational(Long.MaxValue) + Rational(1,5))))
   check(pairs)
 
   @Param(Array("li_li", "lf_lf", "lf_lf_intermediateBig", "bf_bf"))

--- a/benchmark/src/main/scala/spire/benchmark/SafeLongBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/SafeLongBenchmarks.scala
@@ -21,14 +21,14 @@ object SafeLongUtil {
     classify(a) + "_" + classify(b) + "_" + classify(a_op_b)
 
   def check(cases: Map[String, (SafeLong, SafeLong)]): Unit = {
-    for ((kind, (a, b)) ← cases) {
+    for ((kind, (a, b)) <- cases) {
       val c = classify(a, b)
       require(kind.startsWith(c), s"Unexpected class $c for case $kind")
     }
   }
 
-  def check(cases: Map[String, (SafeLong, SafeLong)], op: (SafeLong, SafeLong) ⇒ SafeLong): Unit = {
-    for ((kind, (a, b)) ← cases) {
+  def check(cases: Map[String, (SafeLong, SafeLong)], op: (SafeLong, SafeLong) => SafeLong): Unit = {
+    for ((kind, (a, b)) <- cases) {
       val c = classify(a, b, op(a, b))
       require(kind.startsWith(c), s"Unexpected class $c for case $kind")
     }
@@ -41,13 +41,13 @@ object SafeLongUtil {
 class SafeLongMultiplyBenchmark {
 
   val pairs: Map[String, (SafeLong, SafeLong)] = Map(
-    "l_l_l" → ((SafeLong.two, SafeLong.two)),
-    "l_l_b" → ((SafeLong.two, SafeLong.safe64 - 1)),
-    "l_b_l" → ((SafeLong.minusOne, SafeLong.safe64)),
-    "l_b_b" → ((SafeLong.two, SafeLong.safe64)),
-    "b_l_l" → ((SafeLong.safe64, SafeLong.minusOne)),
-    "b_l_b" → ((SafeLong.safe64, SafeLong.two)),
-    "b_b_b" → ((SafeLong.safe64, SafeLong.safe64))
+    "l_l_l" -> ((SafeLong.two, SafeLong.two)),
+    "l_l_b" -> ((SafeLong.two, SafeLong.safe64 - 1)),
+    "l_b_l" -> ((SafeLong.minusOne, SafeLong.safe64)),
+    "l_b_b" -> ((SafeLong.two, SafeLong.safe64)),
+    "b_l_l" -> ((SafeLong.safe64, SafeLong.minusOne)),
+    "b_l_b" -> ((SafeLong.safe64, SafeLong.two)),
+    "b_b_b" -> ((SafeLong.safe64, SafeLong.safe64))
   )
   check(pairs, _ * _)
 
@@ -80,14 +80,14 @@ class SafeLongMultiplyBenchmark {
 class SafeLongAddSubtractBenchmark {
 
   val pairs: Map[String, (SafeLong, SafeLong)] = Map(
-    "l_l_l" → ((SafeLong.one, SafeLong.one)),
-    "l_l_b" → ((SafeLong.one, SafeLong.safe64 - 1)),
-    "l_b_l" → ((SafeLong.minusOne, SafeLong.safe64)),
-    "l_b_b" → ((SafeLong.one, SafeLong.safe64)),
-    "b_l_l" → ((SafeLong.safe64, SafeLong.minusOne)),
-    "b_l_b" → ((SafeLong.safe64, SafeLong.one)),
-    "b_b_l" → ((SafeLong.safe64, -SafeLong.safe64 - 1)),
-    "b_b_b" → ((SafeLong.safe64, SafeLong.safe64))
+    "l_l_l" -> ((SafeLong.one, SafeLong.one)),
+    "l_l_b" -> ((SafeLong.one, SafeLong.safe64 - 1)),
+    "l_b_l" -> ((SafeLong.minusOne, SafeLong.safe64)),
+    "l_b_b" -> ((SafeLong.one, SafeLong.safe64)),
+    "b_l_l" -> ((SafeLong.safe64, SafeLong.minusOne)),
+    "b_l_b" -> ((SafeLong.safe64, SafeLong.one)),
+    "b_b_l" -> ((SafeLong.safe64, -SafeLong.safe64 - 1)),
+    "b_b_b" -> ((SafeLong.safe64, SafeLong.safe64))
   )
   check(pairs, _ + _)
   check(pairs, _ - -_)
@@ -124,8 +124,8 @@ class SafeLongAddSubtractBenchmark {
 class SafeLongCompareBenchmark {
 
   val pairs: Map[String, (SafeLong, SafeLong)] = Map(
-    "l_l" → ((SafeLong.one, SafeLong.one + 1)),
-    "b_b" → ((SafeLong.safe64, SafeLong.safe64 + 1))
+    "l_l" -> ((SafeLong.one, SafeLong.one + 1)),
+    "b_b" -> ((SafeLong.safe64, SafeLong.safe64 + 1))
   )
   check(pairs)
 

--- a/laws/src/main/scala/spire/laws/ActionLaws.scala
+++ b/laws/src/main/scala/spire/laws/ActionLaws.scala
@@ -33,7 +33,7 @@ trait ActionLaws[G, A] extends Laws {
     sl = _.semigroup(G0),
     parents = Seq.empty,
 
-    "left compatibility" → forAllSafe { (g: G, h: G, a: A) =>
+    "left compatibility" -> forAllSafe { (g: G, h: G, a: A) =>
       ((g |+| h) |+|> a) === (g |+|> (h |+|> a))
     }
   )
@@ -43,7 +43,7 @@ trait ActionLaws[G, A] extends Laws {
     sl = _.semigroup(G0),
     parents = Seq.empty,
 
-    "right compatibility" → forAllSafe { (a: A, g: G, h: G) =>
+    "right compatibility" -> forAllSafe { (a: A, g: G, h: G) =>
       (a <|+| (g |+| h)) === ((a <|+| g) <|+| h)
     }
   )
@@ -59,7 +59,7 @@ trait ActionLaws[G, A] extends Laws {
     sl = _.monoid(G0),
     parents = Seq(leftSemigroupAction),
 
-    "left identity" → forAllSafe { (a: A) =>
+    "left identity" -> forAllSafe { (a: A) =>
       (G0.empty |+|> a) === a
     }
   )
@@ -69,7 +69,7 @@ trait ActionLaws[G, A] extends Laws {
     sl = _.monoid(G0),
     parents = Seq(rightSemigroupAction),
 
-    "right identity" → forAllSafe { (a: A) =>
+    "right identity" -> forAllSafe { (a: A) =>
       (a <|+| G0.empty) === a
     }
   )
@@ -85,7 +85,7 @@ trait ActionLaws[G, A] extends Laws {
     sl = _.group(G0),
     parents = Seq(monoidAction),
 
-    "left and right action compatibility" → forAllSafe { (a: A, g: G) =>
+    "left and right action compatibility" -> forAllSafe { (a: A, g: G) =>
       (a <|+| g) === (g.inverse |+|> a)
     }
   )
@@ -106,7 +106,7 @@ trait ActionLaws[G, A] extends Laws {
     val parents: Seq[ActionProperties],
     val props: (String, Prop)*
   ) extends RuleSet {
-    val bases = Seq("scalar" → sl(scalarLaws))
+    val bases = Seq("scalar" -> sl(scalarLaws))
   }
 
   class AdditiveProperties(
@@ -115,7 +115,7 @@ trait ActionLaws[G, A] extends Laws {
     val props: (String, Prop)*
   ) extends RuleSet with HasOneParent {
     val name = base.name
-    val bases = Seq("base" → base)
+    val bases = Seq("base" -> base)
   }
 
   class MultiplicativeProperties(
@@ -124,6 +124,6 @@ trait ActionLaws[G, A] extends Laws {
     val props: (String, Prop)*
   ) extends RuleSet with HasOneParent {
     val name = base.name
-    val bases = Seq("base" → base)
+    val bases = Seq("base" -> base)
   }
 }

--- a/laws/src/main/scala/spire/laws/BaseLaws.scala
+++ b/laws/src/main/scala/spire/laws/BaseLaws.scala
@@ -25,21 +25,21 @@ trait BaseLaws[A] extends Laws {
 
   def metricSpace[R](implicit MSA: MetricSpace[A, R], SR: Signed[R], OR: Order[R], ASR: AdditiveSemigroup[R]) = new SimpleRuleSet(
     name = "metricSpace",
-    "non-negative" → forAllSafe((a1: A, a2: A) =>
+    "non-negative" -> forAllSafe((a1: A, a2: A) =>
       MSA.distance(a1, a2).sign != Sign.Negative
     ),
-    "identity" → forAllSafe((a: A) =>
+    "identity" -> forAllSafe((a: A) =>
       MSA.distance(a, a).sign == Sign.Zero
     ),
-    "equality" → forAllSafe((a1: A, a2: A) =>
+    "equality" -> forAllSafe((a1: A, a2: A) =>
       // generating equal values is hard, and Scalacheck will give up if it can't
       // hence, not using `==>` here
       a1 =!= a2 || MSA.distance(a1, a2).sign == Sign.Zero
     ),
-    "symmetry" → forAllSafe((a1: A, a2: A) =>
+    "symmetry" -> forAllSafe((a1: A, a2: A) =>
       MSA.distance(a1, a2) === MSA.distance(a2, a1)
     ),
-    "triangleInequality" → forAllSafe((a1: A, a2: A, a3: A) =>
+    "triangleInequality" -> forAllSafe((a1: A, a2: A, a3: A) =>
       (MSA.distance(a1, a2) + MSA.distance(a2, a3)) >= MSA.distance(a1, a3)
     )
   )
@@ -47,13 +47,13 @@ trait BaseLaws[A] extends Laws {
 
   def uniqueFactorizationDomain(implicit A: UniqueFactorizationDomain[A], RA: CRing[A]) = new SimpleRuleSet(
     name = "uniqueFactorizationDomain",
-    "all factors are prime" → forAllSafe( (x: A) =>
+    "all factors are prime" -> forAllSafe( (x: A) =>
       RA.isZero(x) || {
         val factorization = A.factor(x)
         factorization.elements.forall(pair => A.isPrime(pair._1))
       }
     ),
-    "multiplying factors returns the original element" → forAllSafe( (x: A) =>
+    "multiplying factors returns the original element" -> forAllSafe( (x: A) =>
       RA.isZero(x) || {
         val factorization = A.factor(x)
         val prod = factorization.elements.map(f => RA.pow(f._1, f._2) ).foldLeft(RA.one)(RA.times)
@@ -61,7 +61,7 @@ trait BaseLaws[A] extends Laws {
       }
     )
   )
- 
+
 }
 
 // vim: expandtab:ts=2:sw=2

--- a/laws/src/main/scala/spire/laws/CombinationLaws.scala
+++ b/laws/src/main/scala/spire/laws/CombinationLaws.scala
@@ -16,7 +16,7 @@ object CombinationLaws {
 }
 
 /** Contains laws that are obeying by combination of types, for example
-  * various kinds of signed rings. 
+  * various kinds of signed rings.
   */
 trait CombinationLaws[A] extends Laws {
 
@@ -26,10 +26,10 @@ trait CombinationLaws[A] extends Laws {
   def signedAdditiveCMonoid(implicit signedA: Signed[A], additiveCMonoidA: AdditiveCMonoid[A]) = new DefaultRuleSet(
     name = "signedAdditiveCMonoid",
     parent = None,
-    "ordered group" → forAllSafe { (x: A, y: A, z: A) =>
+    "ordered group" -> forAllSafe { (x: A, y: A, z: A) =>
       !(x <= y) || (x + z <= y + z) // replaces (x <= y) ==> (x + z <= y + z)
     },
-    "triangle inequality" → forAllSafe { (x: A, y: A) =>
+    "triangle inequality" -> forAllSafe { (x: A, y: A) =>
       (x + y).abs <= x.abs + y.abs
     }
   )
@@ -37,7 +37,7 @@ trait CombinationLaws[A] extends Laws {
   def signedAdditiveAbGroup(implicit signedA: Signed[A], additiveAbGroupA: AdditiveAbGroup[A]) = new DefaultRuleSet(
     name = "signedAdditiveAbGroup",
     parent = Some(signedAdditiveCMonoid),
-    "abs(x) equals abs(-x)" → forAllSafe { (x: A) =>
+    "abs(x) equals abs(-x)" -> forAllSafe { (x: A) =>
       x.abs === (-x).abs
     }
   )
@@ -48,10 +48,10 @@ trait CombinationLaws[A] extends Laws {
   def signedGCDRing(implicit signedA: Signed[A], gcdRingA: GCDRing[A]) = new DefaultRuleSet(
     name = "signedGCDRing",
     parent = Some(signedAdditiveAbGroup),
-    "gcd(x, y) >= 0" → forAllSafe { (x: A, y: A) =>
+    "gcd(x, y) >= 0" -> forAllSafe { (x: A, y: A) =>
       x.gcd(y).signum >= 0
     },
-    "gcd(x, 0) === abs(x)" → forAllSafe { (x: A) =>
+    "gcd(x, 0) === abs(x)" -> forAllSafe { (x: A) =>
       x.gcd(Ring[A].zero) === Signed[A].abs(x)
     }
   )

--- a/laws/src/main/scala/spire/laws/GroupLaws.scala
+++ b/laws/src/main/scala/spire/laws/GroupLaws.scala
@@ -28,13 +28,13 @@ trait GroupLaws[A] extends Laws {
   def semigroup(implicit A: Semigroup[A]) = new GroupProperties(
     name = "semigroup",
     parent = None,
-    "associative" → forAllSafe((x: A, y: A, z: A) =>
+    "associative" -> forAllSafe((x: A, y: A, z: A) =>
       ((x |+| y) |+| z) === (x |+| (y |+| z))
     ),
-    "combineN(a, 1) === a" → forAllSafe((a: A) =>
+    "combineN(a, 1) === a" -> forAllSafe((a: A) =>
       A.combineN(a, 1) === a
     ),
-    "combineN(a, 2) === a |+| a" → forAllSafe((a: A) =>
+    "combineN(a, 2) === a |+| a" -> forAllSafe((a: A) =>
       A.combineN(a, 2) === (a |+| a)
     )
   )
@@ -42,19 +42,19 @@ trait GroupLaws[A] extends Laws {
   def monoid(implicit A: Monoid[A]) = new GroupProperties(
     name = "monoid",
     parent = Some(semigroup),
-    "left identity" → forAllSafe((x: A) =>
+    "left identity" -> forAllSafe((x: A) =>
       (A.empty |+| x) === x
     ),
-    "right identity" → forAllSafe((x: A) =>
+    "right identity" -> forAllSafe((x: A) =>
       (x |+| A.empty) === x
     ),
-    "combineN(a, 0) === id" → forAllSafe((a: A) =>
+    "combineN(a, 0) === id" -> forAllSafe((a: A) =>
       A.combineN(a, 0) === A.empty
     ),
-    "combineAll(Nil) === id" → forAllSafe((a: A) =>
+    "combineAll(Nil) === id" -> forAllSafe((a: A) =>
       A.combineAll(Nil) === A.empty
     ),
-    "isId" → forAllSafe((x: A) =>
+    "isId" -> forAllSafe((x: A) =>
       (x === A.empty) === (x.isEmpty)
     )
   )
@@ -62,7 +62,7 @@ trait GroupLaws[A] extends Laws {
   def cMonoid(implicit A: CMonoid[A]) = new GroupProperties(
     name = "commutative monoid",
     parent = Some(monoid),
-    "commutative" → forAllSafe((x: A, y: A) =>
+    "commutative" -> forAllSafe((x: A, y: A) =>
       (x |+| y) === (y |+| x)
     )
   )
@@ -70,10 +70,10 @@ trait GroupLaws[A] extends Laws {
   def group(implicit A: Group[A]) = new GroupProperties(
     name = "group",
     parent = Some(monoid),
-    "left inverse" → forAllSafe((x: A) =>
+    "left inverse" -> forAllSafe((x: A) =>
       A.empty === (x.inverse |+| x)
     ),
-    "right inverse" → forAllSafe((x: A) =>
+    "right inverse" -> forAllSafe((x: A) =>
       A.empty === (x |+| x.inverse)
     )
   )
@@ -81,7 +81,7 @@ trait GroupLaws[A] extends Laws {
   def abGroup(implicit A: AbGroup[A]) = new GroupProperties(
     name = "abelian group",
     parent = Some(group),
-    "commutative" → forAllSafe((x: A, y: A) =>
+    "commutative" -> forAllSafe((x: A, y: A) =>
       (x |+| y) === (y |+| x)
     )
   )
@@ -92,10 +92,10 @@ trait GroupLaws[A] extends Laws {
   def additiveSemigroup(implicit A: AdditiveSemigroup[A]) = new AdditiveProperties(
     base = semigroup(A.additive),
     parent = None,
-    "sumN(a, 1) === a" → forAllSafe((a: A) =>
+    "sumN(a, 1) === a" -> forAllSafe((a: A) =>
       A.sumN(a, 1) === a
     ),
-    "sumN(a, 2) === a + a" → forAllSafe((a: A) =>
+    "sumN(a, 2) === a + a" -> forAllSafe((a: A) =>
       A.sumN(a, 2) === (a + a)
     )
   )
@@ -103,13 +103,13 @@ trait GroupLaws[A] extends Laws {
   def additiveMonoid(implicit A: AdditiveMonoid[A]) = new AdditiveProperties(
     base = monoid(A.additive),
     parent = Some(additiveSemigroup),
-    "sumN(a, 0) === zero" → forAllSafe((a: A) =>
+    "sumN(a, 0) === zero" -> forAllSafe((a: A) =>
       A.sumN(a, 0) === A.zero
     ),
-    "sum(Nil) === zero" → forAllSafe((a: A) =>
+    "sum(Nil) === zero" -> forAllSafe((a: A) =>
       A.sum(Nil) === A.zero
     ),
-    "isZero" → forAllSafe((a: A) =>
+    "isZero" -> forAllSafe((a: A) =>
       a.isZero === (a === A.zero)
     )
   )
@@ -123,7 +123,7 @@ trait GroupLaws[A] extends Laws {
   def additiveGroup(implicit A: AdditiveGroup[A]) = new AdditiveProperties(
     base = group(A.additive),
     parent = Some(additiveMonoid),
-    "minus consistent" → forAllSafe((x: A, y: A) =>
+    "minus consistent" -> forAllSafe((x: A, y: A) =>
       (x - y) === (x + (-y))
     )
   )
@@ -148,7 +148,7 @@ trait GroupLaws[A] extends Laws {
     val props: (String, Prop)*
   ) extends RuleSet with HasOneParent {
     val name = base.name
-    val bases = Seq("base" → base)
+    val bases = Seq("base" -> base)
   }
 
 }

--- a/laws/src/main/scala/spire/laws/LatticeLaws.scala
+++ b/laws/src/main/scala/spire/laws/LatticeLaws.scala
@@ -28,13 +28,13 @@ trait LatticeLaws[A] extends Laws {
   def joinSemilattice(implicit A: JoinSemilattice[A]) = new LatticeProperties(
     name = "joinSemilattice",
     parents = Nil,
-    "join.associative" → forAllSafe((x: A, y: A, z: A) =>
+    "join.associative" -> forAllSafe((x: A, y: A, z: A) =>
       ((x join y) join z) === (x join (y join z))
     ),
-    "join.commutative" → forAllSafe((x: A, y: A) =>
+    "join.commutative" -> forAllSafe((x: A, y: A) =>
       (x join y) === (y join x)
     ),
-    "join.idempotent" → forAllSafe((x: A) =>
+    "join.idempotent" -> forAllSafe((x: A) =>
       (x join x) === x
     )
   )
@@ -42,13 +42,13 @@ trait LatticeLaws[A] extends Laws {
   def meetSemilattice(implicit A: MeetSemilattice[A]) = new LatticeProperties(
     name = "meetSemilattice",
     parents = Nil,
-    "meet.associative" → forAllSafe((x: A, y: A, z: A) =>
+    "meet.associative" -> forAllSafe((x: A, y: A, z: A) =>
       ((x meet y) meet z) === (x meet (y meet z))
     ),
-    "meet.commutative" → forAllSafe((x: A, y: A) =>
+    "meet.commutative" -> forAllSafe((x: A, y: A) =>
       (x meet y) === (y meet x)
     ),
-    "meet.idempotent" → forAllSafe((x: A) =>
+    "meet.idempotent" -> forAllSafe((x: A) =>
       (x meet x) === x
     )
   )
@@ -56,7 +56,7 @@ trait LatticeLaws[A] extends Laws {
   def lattice(implicit A: Lattice[A]) = new LatticeProperties(
     name = "lattice",
     parents = Seq(joinSemilattice, meetSemilattice),
-    "absorption" → forAllSafe((x: A, y: A) =>
+    "absorption" -> forAllSafe((x: A, y: A) =>
       ((x join (x meet y)) === x) &&
         ((x meet (x join y)) === x)
     )
@@ -65,7 +65,7 @@ trait LatticeLaws[A] extends Laws {
   def boundedJoinSemilattice(implicit A: BoundedJoinSemilattice[A]) = new LatticeProperties(
     name = "boundedJoinSemilattice",
     parents = Seq(joinSemilattice),
-    "join.identity" → forAllSafe((x: A) =>
+    "join.identity" -> forAllSafe((x: A) =>
       (x join A.zero) === x && (A.zero join x) === x
     )
   )
@@ -73,7 +73,7 @@ trait LatticeLaws[A] extends Laws {
   def boundedMeetSemilattice(implicit A: BoundedMeetSemilattice[A]) = new LatticeProperties(
     name = "boundedMeetSemilattice",
     parents = Seq(meetSemilattice),
-      "meet.identity" → forAllSafe((x: A) =>
+      "meet.identity" -> forAllSafe((x: A) =>
         (x meet A.one) === x && (A.one meet x) === x
       )
   )

--- a/laws/src/main/scala/spire/laws/LatticePartialOrderLaws.scala
+++ b/laws/src/main/scala/spire/laws/LatticePartialOrderLaws.scala
@@ -27,8 +27,8 @@ trait LatticePartialOrderLaws[A] extends Laws {
   def joinSemilatticePartialOrder(implicit A: JoinSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "joinSemilatticePartialOrder",
     parents = Seq.empty,
-    bases = Seq("order" → OrderLaws[A].partialOrder, "lattice" → LatticeLaws[A].joinSemilattice),
-    "join.lteqv" → forAllSafe((x: A, y: A) =>
+    bases = Seq("order" -> OrderLaws[A].partialOrder, "lattice" -> LatticeLaws[A].joinSemilattice),
+    "join.lteqv" -> forAllSafe((x: A, y: A) =>
       (x <= y) === (y === (x join y))
     )
   )
@@ -36,8 +36,8 @@ trait LatticePartialOrderLaws[A] extends Laws {
   def meetSemilatticePartialOrder(implicit A: MeetSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "meetSemilatticePartialOrder",
     parents = Seq.empty,
-    bases = Seq("order" → OrderLaws[A].partialOrder, "lattice" → LatticeLaws[A].meetSemilattice),
-    "meet.lteqv" → forAllSafe((x: A, y: A) =>
+    bases = Seq("order" -> OrderLaws[A].partialOrder, "lattice" -> LatticeLaws[A].meetSemilattice),
+    "meet.lteqv" -> forAllSafe((x: A, y: A) =>
       (x <= y) === (x === (x meet y))
     )
   )
@@ -51,8 +51,8 @@ trait LatticePartialOrderLaws[A] extends Laws {
   def boundedJoinSemilatticePartialOrder(implicit A: BoundedJoinSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedJoinSemilatticePartialOrder",
     parents = Seq(joinSemilatticePartialOrder),
-    bases = Seq("lattice" → LatticeLaws[A].boundedJoinSemilattice),
-    "lteqv.zero" → forAllSafe((x: A) =>
+    bases = Seq("lattice" -> LatticeLaws[A].boundedJoinSemilattice),
+    "lteqv.zero" -> forAllSafe((x: A) =>
       A.zero <= x
     )
   )
@@ -60,8 +60,8 @@ trait LatticePartialOrderLaws[A] extends Laws {
   def boundedMeetSemilatticePartialOrder(implicit A: BoundedMeetSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedMeetSemilatticePartialOrder",
     parents = Seq(meetSemilatticePartialOrder),
-    bases = Seq("lattice" → LatticeLaws[A].boundedMeetSemilattice),
-    "lteqv.one" → forAllSafe((x: A) =>
+    bases = Seq("lattice" -> LatticeLaws[A].boundedMeetSemilattice),
+    "lteqv.one" -> forAllSafe((x: A) =>
       x <= A.one
     )
   )
@@ -69,19 +69,19 @@ trait LatticePartialOrderLaws[A] extends Laws {
   def boundedBelowLatticePartialOrder(implicit A: Lattice[A] with BoundedJoinSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedBelowLatticePartialOrder",
     parents = Seq(boundedJoinSemilatticePartialOrder, latticePartialOrder),
-    bases = Seq("lattice" → LatticeLaws[A].boundedBelowLattice)
+    bases = Seq("lattice" -> LatticeLaws[A].boundedBelowLattice)
   )
 
   def boundedAboveLatticePartialOrder(implicit A: Lattice[A] with BoundedMeetSemilattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedAboveLatticePartialOrder",
     parents = Seq(boundedMeetSemilatticePartialOrder, latticePartialOrder),
-    bases = Seq("lattice" → LatticeLaws[A].boundedAboveLattice)
+    bases = Seq("lattice" -> LatticeLaws[A].boundedAboveLattice)
   )
 
   def boundedLatticePartialOrder(implicit A: BoundedLattice[A], P: PartialOrder[A]) = new LatticePartialOrderProperties(
     name = "boundedLatticePartialOrder",
     parents = Seq(boundedJoinSemilatticePartialOrder, boundedMeetSemilatticePartialOrder),
-    bases = Seq("lattice" → LatticeLaws[A].boundedLattice)
+    bases = Seq("lattice" -> LatticeLaws[A].boundedLattice)
   )
 
   class LatticePartialOrderProperties(

--- a/laws/src/main/scala/spire/laws/LogicLaws.scala
+++ b/laws/src/main/scala/spire/laws/LogicLaws.scala
@@ -51,36 +51,36 @@ trait LogicLaws[A] extends Laws {
 
       "consistent" -> forAllSafe { (x: A) => (x & ~x) === A.zero },
 
-      "¬x = (x → 0)" -> forAllSafe { (x: A) => ~x === (x imp A.zero) },
+      "¬x = (x -> 0)" -> forAllSafe { (x: A) => ~x === (x imp A.zero) },
 
-      "x → x = 1" -> forAllSafe { (x: A) => (x imp x) === A.one },
+      "x -> x = 1" -> forAllSafe { (x: A) => (x imp x) === A.one },
 
-      "if x → y and y → x then x=y" -> forAllSafe { (x: A, y: A) =>
+      "if x -> y and y -> x then x=y" -> forAllSafe { (x: A, y: A) =>
         ((x imp y) =!= A.one) || ((y imp x) =!= A.one) || x === y
       },
 
-      "if (1 → x)=1 then x=1" -> forAllSafe { (x: A) =>
+      "if (1 -> x)=1 then x=1" -> forAllSafe { (x: A) =>
         ((A.one imp x) =!= A.one) || (x === A.one)
       },
 
-      "x → (y → x) = 1" -> forAllSafe { (x: A, y: A) => (x imp (y imp x)) === A.one },
+      "x -> (y -> x) = 1" -> forAllSafe { (x: A, y: A) => (x imp (y imp x)) === A.one },
 
-      "(x→(y→z)) → ((x→y)→(x→z)) = 1" -> forAllSafe { (x: A, y: A, z: A) =>
+      "(x->(y->z)) -> ((x->y)->(x->z)) = 1" -> forAllSafe { (x: A, y: A, z: A) =>
         ((x imp (y imp z)) imp ((x imp y) imp (x imp z))) === A.one
       },
 
-      "x∧y → x = 1" -> forAllSafe { (x: A, y: A) => ((x & y) imp x) === A.one },
-      "x∧y → y = 1" -> forAllSafe { (x: A, y: A) => ((x & y) imp y) === A.one },
-      "x → y → (x∧y) = 1" -> forAllSafe { (x: A, y: A) => (x imp (y imp (x & y))) === A.one },
+      "x∧y -> x = 1" -> forAllSafe { (x: A, y: A) => ((x & y) imp x) === A.one },
+      "x∧y -> y = 1" -> forAllSafe { (x: A, y: A) => ((x & y) imp y) === A.one },
+      "x -> y -> (x∧y) = 1" -> forAllSafe { (x: A, y: A) => (x imp (y imp (x & y))) === A.one },
 
-      "x → x∨y" -> forAllSafe { (x: A, y: A) => (x imp (x | y)) === A.one },
-      "y → x∨y" -> forAllSafe { (x: A, y: A) => (y imp (x | y)) === A.one },
+      "x -> x∨y" -> forAllSafe { (x: A, y: A) => (x imp (x | y)) === A.one },
+      "y -> x∨y" -> forAllSafe { (x: A, y: A) => (y imp (x | y)) === A.one },
 
-      "(x → z) → ((y → z) → ((x | y) → z)) = 1" -> forAllSafe { (x: A, y: A, z: A) =>
+      "(x -> z) -> ((y -> z) -> ((x | y) -> z)) = 1" -> forAllSafe { (x: A, y: A, z: A) =>
         ((x imp z) imp ((y imp z) imp ((x | y) imp z))) === A.one
       },
 
-      "(0 → x) = 1" -> forAllSafe { (x: A) => (A.zero imp x) === A.one }
+      "(0 -> x) = 1" -> forAllSafe { (x: A) => (A.zero imp x) === A.one }
     )
 
   def bool(implicit A: Bool[A]) =

--- a/laws/src/main/scala/spire/laws/OrderLaws.scala
+++ b/laws/src/main/scala/spire/laws/OrderLaws.scala
@@ -26,22 +26,22 @@ trait OrderLaws[A] extends Laws {
   def partialOrder(implicit A: PartialOrder[A]) = new OrderProperties(
     name = "partialOrder",
     parent = None,
-    "reflexitivity" → forAllSafe((x: A) =>
+    "reflexitivity" -> forAllSafe((x: A) =>
       x <= x
     ),
-    "antisymmetry" → forAllSafe((x: A, y: A) =>
+    "antisymmetry" -> forAllSafe((x: A, y: A) =>
       (x <= y && y <= x) imp (x === y)
     ),
-    "transitivity" → forAllSafe((x: A, y: A, z: A) =>
+    "transitivity" -> forAllSafe((x: A, y: A, z: A) =>
       (x <= y && y <= z) imp (x <= z)
     ),
-    "gteqv" → forAllSafe((x: A, y: A) =>
+    "gteqv" -> forAllSafe((x: A, y: A) =>
       (x <= y) === (y >= x)
     ),
-    "lt" → forAllSafe((x: A, y: A) =>
+    "lt" -> forAllSafe((x: A, y: A) =>
       (x < y) === (x <= y && x =!= y)
     ),
-    "gt" → forAllSafe((x: A, y: A) =>
+    "gt" -> forAllSafe((x: A, y: A) =>
       (x < y) === (y > x)
     )
   )
@@ -49,7 +49,7 @@ trait OrderLaws[A] extends Laws {
   def order(implicit A: Order[A]) = new OrderProperties(
     name = "order",
     parent = Some(partialOrder),
-    "totality" → forAllSafe((x: A, y: A) =>
+    "totality" -> forAllSafe((x: A, y: A) =>
       x <= y || y <= x
     )
   )
@@ -57,13 +57,13 @@ trait OrderLaws[A] extends Laws {
   def signed(implicit A: Signed[A]) = new OrderProperties(
     name = "signed",
     parent = Some(order),
-    "abs non-negative" → forAllSafe((x: A) =>
+    "abs non-negative" -> forAllSafe((x: A) =>
       x.abs.sign != Sign.Negative
     ),
-    "signum returns -1/0/1" → forAllSafe((x: A) =>
+    "signum returns -1/0/1" -> forAllSafe((x: A) =>
       x.signum.abs <= 1
     ),
-    "signum is sign.toInt" → forAllSafe((x: A) =>
+    "signum is sign.toInt" -> forAllSafe((x: A) =>
       x.signum == x.sign.toInt
     )
   )
@@ -71,69 +71,69 @@ trait OrderLaws[A] extends Laws {
   def truncatedDivision(implicit cRigA: CRig[A], truncatedDivisionA: TruncatedDivision[A]) = new DefaultRuleSet(
     name = "truncatedDivision",
     parent = Some(signed),
-    "division rule (tquotmod)" → forAllSafe { (x: A, y: A) =>
+    "division rule (tquotmod)" -> forAllSafe { (x: A, y: A) =>
       y.isZero || {
         val (q, r) = x tquotmod y
         x === y * q + r
       }
     },
-    "division rule (fquotmod)" → forAllSafe { (x: A, y: A) =>
+    "division rule (fquotmod)" -> forAllSafe { (x: A, y: A) =>
       y.isZero || {
         val (q, r) = x fquotmod y
         x == y * q + r
       }
     },
-    "quotient is integer (tquot)" → forAllSafe { (x: A, y: A) =>
+    "quotient is integer (tquot)" -> forAllSafe { (x: A, y: A) =>
       y.isZero || (x tquot y).toBigIntOpt.nonEmpty
     },
-    "quotient is integer (fquot)" → forAllSafe { (x: A, y: A) =>
+    "quotient is integer (fquot)" -> forAllSafe { (x: A, y: A) =>
       y.isZero || (x fquot y).toBigIntOpt.nonEmpty
     },
-    "|r| < |y| (tmod)" → forAllSafe { (x: A, y: A) =>
+    "|r| < |y| (tmod)" -> forAllSafe { (x: A, y: A) =>
       y.isZero || {
         val r = x tmod y
         r.abs < y.abs
       }
     },
-    "|r| < |y| (fmod)" → forAllSafe { (x: A, y: A) =>
+    "|r| < |y| (fmod)" -> forAllSafe { (x: A, y: A) =>
       y.isZero || {
         val r = x fmod y
         r.abs < y.abs
       }
     },
-    "r = 0 or sign(r) = sign(x) (tmod)" → forAllSafe { (x: A, y: A) =>
+    "r = 0 or sign(r) = sign(x) (tmod)" -> forAllSafe { (x: A, y: A) =>
       y.isZero || {
         val r = x tmod y
         r.isZero || (r.sign === x.sign)
       }
     },
-    "r = 0 or sign(r) = sign(y) (fmod)" → forAllSafe { (x: A, y: A) =>
+    "r = 0 or sign(r) = sign(y) (fmod)" -> forAllSafe { (x: A, y: A) =>
       y.isZero || {
         val r = x fmod y
         r.isZero || (r.sign === y.sign)
       }
     },
-    "tquot" → forAllSafe { (x: A, y: A) =>
+    "tquot" -> forAllSafe { (x: A, y: A) =>
       y.isZero || {
         (x tquotmod y)._1 === (x tquot y)
       }
     },
-    "tmod" → forAllSafe { (x: A, y: A) =>
+    "tmod" -> forAllSafe { (x: A, y: A) =>
       y.isZero || {
         (x tquotmod y)._2 === (x tmod y)
       }
     },
-    "fquot" → forAllSafe { (x: A, y: A) =>
+    "fquot" -> forAllSafe { (x: A, y: A) =>
       y.isZero || {
         (x fquotmod y)._1 === (x fquot y)
       }
     },
-    "fmod" → forAllSafe { (x: A, y: A) =>
+    "fmod" -> forAllSafe { (x: A, y: A) =>
       y.isZero || {
         (x fquotmod y)._2 === (x fmod y)
       }
     }
-    
+
   )
 
   class OrderProperties(

--- a/laws/src/main/scala/spire/laws/PartialActionLaws.scala
+++ b/laws/src/main/scala/spire/laws/PartialActionLaws.scala
@@ -34,7 +34,7 @@ trait PartialActionLaws[G, A] extends Laws {
     sl = _.semigroupoid(G0),
     parents = Seq.empty,
 
-    "left compatibility" → forAllSafe { (g: G, h: G, a: A) =>
+    "left compatibility" -> forAllSafe { (g: G, h: G, a: A) =>
       ( (h ??|+|> a) && (g |+|?? h) ) ==>
         ((g |+|? h).get ??|+|> a) && ((g |+|? h).get ?|+|> a).get === (g ?|+|> (h ?|+|> a).get).get
     }
@@ -45,7 +45,7 @@ trait PartialActionLaws[G, A] extends Laws {
     sl = _.semigroupoid(G0),
     parents = Seq.empty,
 
-    "right compatibility" → forAllSafe { (g: G, h: G, a: A) =>
+    "right compatibility" -> forAllSafe { (g: G, h: G, a: A) =>
       ( (a <|+|?? g) && (g |+|?? h) ) ==>
       (a <|+|?? (g |+|? h).get) && ((a <|+|? (g |+|? h).get).get === ((a <|+|? g).get <|+|? h).get)
     }
@@ -62,18 +62,18 @@ trait PartialActionLaws[G, A] extends Laws {
     sl = _.groupoid(G0),
     parents = Seq(semigroupoidPartialAction),
 
-    "left action identity" → forAllSafe { (g: G, a: A) =>
+    "left action identity" -> forAllSafe { (g: G, a: A) =>
       (g ??|+|> a) ==>
       ((g.rightId ??|+|> a) && ((g.rightId ?|+|> a).get === a))
     },
 
-    "right action identity" → forAllSafe { (g: G, a: A) =>
+    "right action identity" -> forAllSafe { (g: G, a: A) =>
       (a <|+|?? g) ==>
       ((a <|+|?? g.leftId) && ((a <|+|? g.leftId).get === a))
     },
 
 
-    "left and right partial action compatibility" → forAllSafe { (a: A, g: G) =>
+    "left and right partial action compatibility" -> forAllSafe { (a: A, g: G) =>
       (a <|+|?? g) ==>
       ((g.inverse ??|+|> a) && ((a <|+|? g).get === (g.inverse ?|+|> a).get))
     }
@@ -84,7 +84,7 @@ trait PartialActionLaws[G, A] extends Laws {
     sl = _.semigroup(G0),
     parents = Seq.empty,
 
-    "left compatibility" → forAllSafe { (g: G, h: G, a: A) =>
+    "left compatibility" -> forAllSafe { (g: G, h: G, a: A) =>
       ( (h ??|+|> a) && ((g |+| h) ??|+|> a) ) ==>
       (((g |+| h) ?|+|> a).get === (g ?|+|> (h ?|+|> a).get).get)
     }
@@ -95,7 +95,7 @@ trait PartialActionLaws[G, A] extends Laws {
     sl = _.semigroup(G0),
     parents = Seq.empty,
 
-    "right compatibility" → forAllSafe { (a: A, g: G, h: G) =>
+    "right compatibility" -> forAllSafe { (a: A, g: G, h: G) =>
       ( (a <|+|?? g) && (a <|+|?? (g |+| h)) ) ==>
       ((a <|+|? (g |+| h)).get === ((a <|+|? g).get <|+|? h).get)
     }
@@ -112,7 +112,7 @@ trait PartialActionLaws[G, A] extends Laws {
     sl = _.monoid(G0),
     parents = Seq(leftSemigroupPartialAction),
 
-    "left identity" → forAllSafe { (a: A) =>
+    "left identity" -> forAllSafe { (a: A) =>
       (G0.empty ??|+|> a) && ((G0.empty ?|+|> a).get === a)
     }
   )
@@ -122,7 +122,7 @@ trait PartialActionLaws[G, A] extends Laws {
     sl = _.monoid(G0),
     parents = Seq(rightSemigroupPartialAction),
 
-    "right identity" → forAllSafe { (a: A) =>
+    "right identity" -> forAllSafe { (a: A) =>
       (a <|+|?? G0.empty) && ((a <|+|? G0.empty).get === a)
     }
   )
@@ -139,11 +139,11 @@ trait PartialActionLaws[G, A] extends Laws {
     sl = _.group(G0),
     parents = Seq(monoidPartialAction),
 
-    "right -> left action compatibility" → forAllSafe { (a: A, g: G) =>
+    "right -> left action compatibility" -> forAllSafe { (a: A, g: G) =>
       !(a <|+|?? g) || ((g ??|+|> a) && ((a <|+|? g).get === (g.inverse ?|+|> a).get))
     },
 
-    "left -> right action compatibility" → forAllSafe { (a: A, g: G) =>
+    "left -> right action compatibility" -> forAllSafe { (a: A, g: G) =>
       !(g ??|+|> a) || ((a <|+|?? g) && ((g ?|+|> a).get === (a <|+|? g.inverse).get))
     }
   )
@@ -154,6 +154,6 @@ trait PartialActionLaws[G, A] extends Laws {
     val parents: Seq[ActionProperties],
     val props: (String, Prop)*
   ) extends RuleSet {
-    val bases = Seq("scalar" → sl(scalarLaws))
+    val bases = Seq("scalar" -> sl(scalarLaws))
   }
 }

--- a/laws/src/main/scala/spire/laws/PartialGroupLaws.scala
+++ b/laws/src/main/scala/spire/laws/PartialGroupLaws.scala
@@ -22,11 +22,11 @@ trait PartialGroupLaws[A] extends GroupLaws[A] {
   def semigroupoid(implicit A: Semigroupoid[A]) = new GroupProperties(
     name = "semigroupoid",
     parent = None,
-    "associative: a |+|?? b && b |+|?? c imply (a |+| b) |+|?? c" → forAllSafe((a: A, b: A, c: A) =>
+    "associative: a |+|?? b && b |+|?? c imply (a |+| b) |+|?? c" -> forAllSafe((a: A, b: A, c: A) =>
       !((a |+|?? b) && (b |+|?? c)) || ((a |+|? b).get |+|?? c)
     ),
 
-    "associative: (a |+|? b) |+|? c === a |+|? (b |+|? c)" → forAllSafe((a: A, b: A, c: A) => {
+    "associative: (a |+|? b) |+|? c === a |+|? (b |+|? c)" -> forAllSafe((a: A, b: A, c: A) => {
       (!(a |+|?? b) || !(b |+|?? c)) ||
       ((a |+|? b).get |+|? c).get === (a |+|? (b |+|? c).get).get
     }
@@ -36,19 +36,19 @@ trait PartialGroupLaws[A] extends GroupLaws[A] {
   def groupoid(implicit A: Groupoid[A]) = new GroupProperties(
     name = "groupoid",
     parent = Some(semigroupoid),
-    "left identity" → forAllSafe((a: A) =>
+    "left identity" -> forAllSafe((a: A) =>
       (a.leftId |+|?? a) && ((a.leftId() |+|? a).get === a)
     ),
 
-    "right identity" → forAllSafe((a: A) =>
+    "right identity" -> forAllSafe((a: A) =>
       (a |+|?? a.rightId) && ((a |+|? a.rightId).get === a)
     ),
 
-    "product with inverse is always defined" → forAllSafe((a: A) =>
+    "product with inverse is always defined" -> forAllSafe((a: A) =>
       (a |+|?? a.inverse) && (a.inverse |+|?? a)
     ),
 
-    "product with inverse is a left and right identity" → forAllSafe((a: A, b: A) =>
+    "product with inverse is a left and right identity" -> forAllSafe((a: A, b: A) =>
       !(a |+|?? b) || (
         ((a |+|? b).get |+|? b.inverse).get === a &&
           ((a.inverse |+|? a).get |+|? b).get === b

--- a/laws/src/main/scala/spire/laws/RingLaws.scala
+++ b/laws/src/main/scala/spire/laws/RingLaws.scala
@@ -44,13 +44,13 @@ trait RingLaws[A] extends GroupLaws[A] {
   def multiplicativeSemigroup(implicit A: MultiplicativeSemigroup[A]) = new MultiplicativeProperties(
     base = _.semigroup(A.multiplicative),
     parent = None,
-    "pow(a, 1) === a" → forAllSafe((a: A) =>
+    "pow(a, 1) === a" -> forAllSafe((a: A) =>
       A.pow(a, 1) === a
     ),
-    "pow(a, 2) === a * a" → forAllSafe((a: A) =>
+    "pow(a, 2) === a * a" -> forAllSafe((a: A) =>
       A.pow(a, 2) === (a * a)
     ),
-    "tryProduct" → forAllSafe((a: A) =>
+    "tryProduct" -> forAllSafe((a: A) =>
       (A.tryProduct(Seq.empty[A]) === Option.empty[A]) &&
         (A.tryProduct(Seq(a)) === Option(a)) &&
         (A.tryProduct(Seq(a, a)) === Option(a * a)) &&
@@ -61,10 +61,10 @@ trait RingLaws[A] extends GroupLaws[A] {
   def multiplicativeMonoid(implicit A: MultiplicativeMonoid[A]) = new MultiplicativeProperties(
     base = _.monoid(A.multiplicative),
     parent = Some(multiplicativeSemigroup),
-    "pow(a, 0) === one" → forAllSafe((a: A) =>
+    "pow(a, 0) === one" -> forAllSafe((a: A) =>
       A.pow(a, 0) === A.one
     ),
-    "product(Nil) === one" → forAllSafe((a: A) =>
+    "product(Nil) === one" -> forAllSafe((a: A) =>
       A.product(Nil) === A.one
     )
   )
@@ -77,7 +77,7 @@ trait RingLaws[A] extends GroupLaws[A] {
   def multiplicativeGroup(implicit A: MultiplicativeGroup[A]) = new MultiplicativeProperties(
     base = _.group(A.multiplicative),
     parent = Some(multiplicativeMonoid),
-    "reciprocal consistent" → forAllSafe((x: A) =>
+    "reciprocal consistent" -> forAllSafe((x: A) =>
       !pred(x) || ((A.one / x) === x.reciprocal)
     )
   )
@@ -95,10 +95,10 @@ trait RingLaws[A] extends GroupLaws[A] {
     al = additiveSemigroup,
     ml = multiplicativeSemigroup,
     parents = Seq.empty,
-    "distributive" → forAllSafe((x: A, y: A, z: A) =>
+    "distributive" -> forAllSafe((x: A, y: A, z: A) =>
       (x * (y + z) === (x * y + x * z)) && (((x + y) * z) === (x * z + y * z))
     ),
-    "pow" → forAllSafe((x: A) =>
+    "pow" -> forAllSafe((x: A) =>
       ((x pow 1) === x) && ((x pow 2) === x * x) && ((x pow 3) === x * x * x)
     )
   )
@@ -152,55 +152,55 @@ trait RingLaws[A] extends GroupLaws[A] {
   def gcdRing(implicit A: GCDRing[A]) = RingProperties.fromParent(
     name = "gcd domain",
     parent = cRing,
-    "gcd/lcm" → forAllSafe { (x: A, y: A) =>
+    "gcd/lcm" -> forAllSafe { (x: A, y: A) =>
       import spire.syntax.gcdRing._
       val d = x gcd y
       val m = x lcm y
       x * y === d * m
     },
-    "gcd is commutative" → forAllSafe { (x: A, y: A) =>
+    "gcd is commutative" -> forAllSafe { (x: A, y: A) =>
       import spire.syntax.gcdRing._
         (x gcd y) === (y gcd x)
     },
-    "lcm is commutative" → forAllSafe { (x: A, y: A) =>
+    "lcm is commutative" -> forAllSafe { (x: A, y: A) =>
       import spire.syntax.gcdRing._
       (x lcm y) === (y lcm x)
     },
-    "gcd(0, 0)" → ((A.zero gcd A.zero) === A.zero),
-    "lcm(0, 0) === 0" → ((A.zero lcm A.zero) === A.zero),
-    "lcm(x, 0) === 0" → forAllSafe { (x: A) => (x lcm A.zero) === A.zero }
+    "gcd(0, 0)" -> ((A.zero gcd A.zero) === A.zero),
+    "lcm(0, 0) === 0" -> ((A.zero lcm A.zero) === A.zero),
+    "lcm(x, 0) === 0" -> forAllSafe { (x: A) => (x lcm A.zero) === A.zero }
   )
 
   def euclideanRing(implicit A: EuclideanRing[A]) = RingProperties.fromParent(
     name = "euclidean ring",
     parent = gcdRing,
-    "euclidean division rule" → forAllSafe { (x: A, y: A) =>
+    "euclidean division rule" -> forAllSafe { (x: A, y: A) =>
       import spire.syntax.euclideanRing._
       !pred(y) || {
         val (q, r) = x equotmod y
         x === (y * q + r)
       }
     },
-    "equot" → forAllSafe { (x: A, y: A) =>
+    "equot" -> forAllSafe { (x: A, y: A) =>
       import spire.syntax.euclideanRing._
       !pred(y) || {
         (x equotmod y)._1 === (x equot y)
       }
     },
-    "emod" → forAllSafe { (x: A, y: A) =>
+    "emod" -> forAllSafe { (x: A, y: A) =>
       import spire.syntax.euclideanRing._
       !pred(y) || {
         (x equotmod y)._2 === (x emod y)
       }
     },
-    "euclidean function" → forAllSafe { (x: A, y: A) =>
+    "euclidean function" -> forAllSafe { (x: A, y: A) =>
       import spire.syntax.euclideanRing._
       !pred(y) || {
         val (q, r) = x equotmod y
         r.isZero || (r.euclideanFunction < y.euclideanFunction)
       }
     },
-    "submultiplicative function" → forAllSafe { (x: A, y: A) =>
+    "submultiplicative function" -> forAllSafe { (x: A, y: A) =>
       import spire.syntax.euclideanRing._
       !(pred(x) && pred(y)) || {
         x.euclideanFunction <= (x * y).euclideanFunction
@@ -211,7 +211,7 @@ trait RingLaws[A] extends GroupLaws[A] {
   def integerEuclideanRing(implicit A: EuclideanRing[A], S: Signed[A]) = RingProperties.fromParent(
     name = "integer euclidean ring",
     parent = euclideanRing,
-    "remainder is nonnegative" → forAllSafe { (x: A, y: A) =>
+    "remainder is nonnegative" -> forAllSafe { (x: A, y: A) =>
       import spire.syntax.euclideanRing._
       import spire.syntax.signed._
       !pred(y) || (x emod y).isSignNonNegative
@@ -248,7 +248,7 @@ trait RingLaws[A] extends GroupLaws[A] {
     private val _base = base(RingLaws.this)
 
     val name = _base.name
-    val bases = Seq("base" → _base)
+    val bases = Seq("base" -> _base)
   }
 
   object RingProperties {
@@ -269,14 +269,14 @@ trait RingLaws[A] extends GroupLaws[A] {
       if (nonZero)
         new RuleSet with HasOneParent {
           val name = ml.name
-          val bases = Seq("base-nonzero" → ml.base(nonZeroLaws))
+          val bases = Seq("base-nonzero" -> ml.base(nonZeroLaws))
           val parent = ml.parent
           val props = ml.props
         }
       else
         ml
 
-    def bases = Seq("additive" → al, "multiplicative" → _ml)
+    def bases = Seq("additive" -> al, "multiplicative" -> _ml)
   }
 
 }

--- a/laws/src/main/scala/spire/laws/VectorSpaceLaws.scala
+++ b/laws/src/main/scala/spire/laws/VectorSpaceLaws.scala
@@ -90,14 +90,14 @@ trait VectorSpaceLaws[V, A] extends Laws {
     sl = _.emptyRuleSet,
     vl = _.emptyRuleSet,
     parents = Seq.empty,
-    "identity" → forAllSafe((x: V, y: V) =>
+    "identity" -> forAllSafe((x: V, y: V) =>
       if (x === y) V.distance(x, y) === A.zero
       else V.distance(x, y) =!= A.zero
     ),
-    "symmetric" → forAllSafe((x: V, y: V) =>
+    "symmetric" -> forAllSafe((x: V, y: V) =>
       V.distance(x, y) === V.distance(y, x)
     ),
-    "triangle inequality" → forAllSafe((x: V, y: V, z: V) =>
+    "triangle inequality" -> forAllSafe((x: V, y: V, z: V) =>
       V.distance(x, z) <= (V.distance(x, y) + V.distance(y, z))
     )
   )
@@ -108,10 +108,10 @@ trait VectorSpaceLaws[V, A] extends Laws {
     vl = _.abGroup(V.additive),
     parents = Seq(vectorSpace, metricSpace),
 
-    "scalable" → forAllSafe((a: A, v: V) =>
+    "scalable" -> forAllSafe((a: A, v: V) =>
       a.abs * v.norm === (a.abs *: v).norm
     ),
-    "only 1 zero" → forAllSafe((v: V) => // This is covered by metricSpace...
+    "only 1 zero" -> forAllSafe((v: V) => // This is covered by metricSpace...
       if (v === V.zero)
         v.norm === Rng[A].zero
       else
@@ -122,10 +122,10 @@ trait VectorSpaceLaws[V, A] extends Laws {
   def linearity(f: V => A)(implicit V: CModule[V, A]): SimpleRuleSet = new SimpleRuleSet(
     name = "linearity",
 
-    "homogeneity" → forAllSafe((r: A, v: V) =>
+    "homogeneity" -> forAllSafe((r: A, v: V) =>
       f(r *: v) === r * f(v)
     ),
-    "additivity" → forAllSafe((v: V, w: V) =>
+    "additivity" -> forAllSafe((v: V, w: V) =>
       f(v + w) === f(v) + f(w)
     )
   )
@@ -135,10 +135,10 @@ trait VectorSpaceLaws[V, A] extends Laws {
     name = "inner-product space",
     parent = vectorSpace,
 
-    "symmetry" → forAllSafe((v: V, w: V) =>
+    "symmetry" -> forAllSafe((v: V, w: V) =>
       (v ⋅ w).abs === (w ⋅ v).abs
     ),
-    "linearity of partial inner product" → forAllSafe((w: V) =>
+    "linearity of partial inner product" -> forAllSafe((w: V) =>
       // TODO this probably requires some thought -- should `linearity` be a full `RuleSet`?
       propertiesToProp(linearity(_ ⋅ w).all)
     )
@@ -156,7 +156,7 @@ trait VectorSpaceLaws[V, A] extends Laws {
     val parents: Seq[SpaceProperties],
     val props: (String, Prop)*
   ) extends RuleSet {
-    val bases = Seq("scalar" → sl(scalarLaws), "vector" → vl(vectorLaws))
+    val bases = Seq("scalar" -> sl(scalarLaws), "vector" -> vl(vectorLaws))
   }
 
 }

--- a/laws/src/main/scala/spire/laws/gen.scala
+++ b/laws/src/main/scala/spire/laws/gen.scala
@@ -44,9 +44,9 @@ object gen {
 
   lazy val safeLong: Gen[SafeLong] =
     Gen.frequency(
-      1 → SafeLong(BigInt("393050634124102232869567034555427371542904833")),
-      100 → arbitrary[Long].map(SafeLong(_)),
-      100 → arbitrary[BigInt].map(SafeLong(_)))
+      1 -> SafeLong(BigInt("393050634124102232869567034555427371542904833")),
+      100 -> arbitrary[Long].map(SafeLong(_)),
+      100 -> arbitrary[BigInt].map(SafeLong(_)))
 
   lazy val natural: Gen[Natural] =
     Gen.oneOf(
@@ -72,11 +72,11 @@ object gen {
     }
 
     Gen.frequency(
-      10 → rationalFromLongs, // we keep this to make long/long rationals more frequent
-      10 → arbitrary[Double].map(n => Rational(n)),
-      1 → rationalFromSafeLongs,
-      1 → bigRational, // a rational that is guaranteed to have a big denominator
-      1 → bigRational.map(x ⇒ if(x.isZero) Rational.one else x.inverse)
+      10 -> rationalFromLongs, // we keep this to make long/long rationals more frequent
+      10 -> arbitrary[Double].map(n => Rational(n)),
+      1 -> rationalFromSafeLongs,
+      1 -> bigRational, // a rational that is guaranteed to have a big denominator
+      1 -> bigRational.map(x => if(x.isZero) Rational.one else x.inverse)
     )
   }
 

--- a/tests/src/test/scala/spire/laws/ArbTest.scala
+++ b/tests/src/test/scala/spire/laws/ArbTest.scala
@@ -60,16 +60,16 @@ class ArbTest extends AnyFunSuite {
     import spire.std.int._
     val samples = sampleArray(100, spire.laws.arb.interval[Int].arbitrary)
     def classify(x: Interval[Int]): String = x.fold {
-      case (Unbound(), Unbound()) ⇒ "all"
-      case (Unbound(), Open(_)) ⇒ ")"
-      case (Unbound(), Closed(_)) ⇒ "]"
-      case (Open(_), Unbound()) ⇒ "("
-      case (Closed(_), Unbound()) ⇒ "["
-      case (Open(_), Open(_)) ⇒ "()"
-      case (Open(_), Closed(_)) ⇒ "(]"
-      case (Closed(_), Open(_)) ⇒ "[)"
-      case (Closed(a), Closed(b)) ⇒ if(a!=b) "[]" else "point"
-      case _ ⇒ "empty"
+      case (Unbound(), Unbound()) => "all"
+      case (Unbound(), Open(_)) => ")"
+      case (Unbound(), Closed(_)) => "]"
+      case (Open(_), Unbound()) => "("
+      case (Closed(_), Unbound()) => "["
+      case (Open(_), Open(_)) => "()"
+      case (Open(_), Closed(_)) => "(]"
+      case (Closed(_), Open(_)) => "[)"
+      case (Closed(a), Closed(b)) => if(a!=b) "[]" else "point"
+      case _ => "empty"
     }
     val kinds = samples.map(classify).distinct.sorted
     assert(kinds.length == 11)

--- a/tests/src/test/scala/spire/math/ComplexCheck.scala
+++ b/tests/src/test/scala/spire/math/ComplexCheck.scala
@@ -53,14 +53,14 @@ class ComplexCheck extends PropSpec with Matchers with ScalaCheckDrivenPropertyC
   complex2("x + y - x == y") { (x: C, y: C) => near(x + y - x, y) }
   complex2("(x / y) * y == x") { (x: C, y: C) => if (y != zero) near((x / y) * y, x) }
 
-  complex1("x.sqrt.pow(2) = x") { x: C ⇒
+  complex1("x.sqrt.pow(2) = x") { x: C =>
     implicit val threshold = BigDecimal(2e-9)  // 28254913+1i gives a log-error-ratio of 2.02e-9
     logNear(x.sqrt.pow(2), x)
   }
 
   // use x*x instead of x.pow(2) because of rounding issues with the latter resulting in some brittleness about whether
   // a subsequent sqrt ends up in the first or fourth quadrants
-  complex1("(x*x).sqrt = x") { x: C ⇒
+  complex1("(x*x).sqrt = x") { x: C =>
     implicit val threshold = BigDecimal(3e-9)  // 1+110201870i has log-error-ratio 2.4e-9
     // Complex.sqrt returns the root with non-negative real value (and +i in the case of -1); adjust the "expected" RHS
     // accordingly
@@ -70,7 +70,7 @@ class ComplexCheck extends PropSpec with Matchers with ScalaCheckDrivenPropertyC
       logNear((x*x).sqrt, x)
   }
 
-  complex1("x.nroot(2).pow(2) = x") { x: C ⇒
+  complex1("x.nroot(2).pow(2) = x") { x: C =>
     if (spire.scalacompat.preScala2p13) {
       // this test inf-loops on scala 2.13
       implicit val threshold = BigDecimal(1e-14) // 532788694 + 329i has log-error-ratio 1.1e-15

--- a/tests/src/test/scala/spire/math/RationalTest.scala
+++ b/tests/src/test/scala/spire/math/RationalTest.scala
@@ -324,7 +324,7 @@ class RationalTest extends AnyFunSuite {
     val z = Rational("1/287380324068203382157064120376241062")
     assert(x.gcd(y) === z) // As confirmed by Wolfram Alpha
     // test gcd special cases (0 and 1)
-    for(w ← Seq(Rational(Int.MaxValue), Rational(BigInt(2).pow(100)))) {
+    for(w <- Seq(Rational(Int.MaxValue), Rational(BigInt(2).pow(100)))) {
       val n = -w
       assert(Rational.zero.gcd(w) === w)
       assert(w.gcd(Rational.zero) === w)

--- a/tests/src/test/scala/spire/math/SafeLongTest.scala
+++ b/tests/src/test/scala/spire/math/SafeLongTest.scala
@@ -51,13 +51,13 @@ class SafeLongTest extends AnyFunSuite {
     assert((SafeLong.minusOne << 1) == SafeLong(-1 << 1))
   }
   test("safeLongIsSigned") {
-    for(x ← Seq(SafeLong.one)) {
+    for(x <- Seq(SafeLong.one)) {
       assert(Signed[SafeLong].signum(x) == x.signum)
       assert(Signed[SafeLong].abs(x) == x.abs)
       assert(IsIntegral[SafeLong].toDouble(x) == x.toDouble)
       assert(IsIntegral[SafeLong].toBigInt(x) == x.toBigInt)
     }
-    for(a ← Seq(SafeLong.one, SafeLong.two); b ← Seq(SafeLong.one, SafeLong.two)) {
+    for(a <- Seq(SafeLong.one, SafeLong.two); b <- Seq(SafeLong.one, SafeLong.two)) {
       assert(Order[SafeLong].compare(a, b) == a.compare(b))
       assert(EuclideanRing[SafeLong].equot(a, b) == a / b)
       assert(EuclideanRing[SafeLong].emod(a, b) == a % b)

--- a/tests/src/test/scala/spire/math/prime/PrimeTest.scala
+++ b/tests/src/test/scala/spire/math/prime/PrimeTest.scala
@@ -9,18 +9,18 @@ import spire.math.SafeLong
 class PrimeTest extends AnyFunSuite {
   val largePrime = SafeLong("393050634124102232869567034555427371542904833")
   val largeNonPrime = largePrime + 4
-  val tenPrimes = IndexedSeq(2, 3, 5, 7, 11, 13, 17, 19, 23, 29).map(x ⇒ SafeLong(x))
-  val nonPrimes = IndexedSeq(10L, 64L, 2L ** 32, 3L ** 10).map(x ⇒ SafeLong(x))
+  val tenPrimes = IndexedSeq(2, 3, 5, 7, 11, 13, 17, 19, 23, 29).map(x => SafeLong(x))
+  val nonPrimes = IndexedSeq(10L, 64L, 2L ** 32, 3L ** 10).map(x => SafeLong(x))
 
   test("nth") {
-    for(i ← tenPrimes.indices)
+    for(i <- tenPrimes.indices)
       assert(nth(i + 1) == tenPrimes(i))
   }
 
   test("isPrime") {
-    for(p ← tenPrimes)
+    for(p <- tenPrimes)
       assert(isPrime(p))
-    for(n ← nonPrimes)
+    for(n <- nonPrimes)
       assert(!isPrime(n))
   }
 
@@ -34,14 +34,14 @@ class PrimeTest extends AnyFunSuite {
   }
 
   test("factor") {
-    for(p ← tenPrimes) {
+    for(p <- tenPrimes) {
       assert(factor(p) == Factors(p))
       assert(factorPollardRho(p) == Factors(p))
       assert(factorTrialDivision(p) == Factors(p))
       assert(factorWheelDivision(p) == Factors(p))
     }
     def terms(f: Factors): Int = f.map(_._2).sum
-    for(n ← nonPrimes) {
+    for(n <- nonPrimes) {
       assert(terms(factor(n)) > 1)
       assert(terms(factorPollardRho(n)) > 1)
       assert(terms(factorTrialDivision(n)) > 1)


### PR DESCRIPTION
Replaces ←, ⇒ and → with <-, => and ->.

Motivation: they're deprecated since Scala 2.13 and they are currently generating tons of warnings in the Scala 2.13 build logs.