### PR TITLE
Improve performance of root finding for big integers.

### DIFF
--- a/core/src/main/scala/spire/std/bigInteger.scala
+++ b/core/src/main/scala/spire/std/bigInteger.scala
@@ -44,7 +44,22 @@ trait BigIntegerIsNRoot extends NRoot[BigInteger] {
         findNroot(b, i - 1)
     }
 
-    findNroot(BigInteger.ZERO, a.bitLength - 1)
+    if (k == 1)
+      a
+    else if (k > 1) {
+      /* The bit length l of b can be interpreted as pow(2, l - 1) <= b < pow(2, l).
+         We thus know that the k-th root of b will satisfy
+           nroot(pow(2, l - 1), k) <= nroot(b, k) < nroot(pow(2, l))
+         Since the k-th root is equivalent to the (1/k)-th power, we can rewrite this as
+           pow(pow(2, l - 1), 1 / k) <= nroot(b, k) < pow(pow(2, l), 1 / k)
+         which, by the power laws, is equivalent to
+           pow(2, (l - 1) / k) <= nroot(b, k) < pow(2, l / k)
+         Thus the k-th root of b will have a bit size of at most l / k.
+      */
+      findNroot(BigInteger.ZERO, a.bitLength / k)
+    }
+    else
+      throw new ArithmeticException("Cannot find non-positive %d-root of an integer number." format k)
   }
   def fpow(a:BigInteger, b:BigInteger): BigInteger = spire.math.pow(BigDecimal(a), BigDecimal(b)).bigDecimal.toBigInteger
 }

--- a/tests/src/test/scala/spire/math/BigIntegerNRootTest.scala
+++ b/tests/src/test/scala/spire/math/BigIntegerNRootTest.scala
@@ -1,0 +1,30 @@
+package spire.math
+
+import java.math.BigInteger
+
+import org.scalacheck.{Arbitrary, Gen, Prop}
+import org.scalatest.NonImplicitAssertions
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.Checkers
+import spire.BaseSyntaxTest
+import spire.algebra.NRoot
+import spire.implicits._
+import spire.compat._
+import spire.laws.arb._
+
+class BigIntegerNRootTest extends AnyFunSuite with Checkers with BaseSyntaxTest with NonImplicitAssertions {
+
+   private val rootGen: Gen[Int] = Gen.posNum[Int] :| "Root"
+   private val bigIntegerGen: Gen[BigInteger] = Arbitrary.arbitrary[BigInteger].map(_.abs()) :| "Base"
+
+   test("NRoot.nroot(n, k) yields the largest number whose k-th power is smaller than or equal to n.")(
+      check(Prop.forAllNoShrink(bigIntegerGen, rootGen) { (x: BigInteger, k: Int) =>
+         testRootProperApproximation(x, k, NRoot[BigInteger].nroot(x, k))
+      }
+      )
+   )
+
+   def testRootProperApproximation(x: BigInteger, k: Int, rootX: BigInteger): Boolean = {
+      rootX.pow(k) <= x && x < (1 + rootX).pow(k)
+   }
+}


### PR DESCRIPTION
The computation of the n-th root of big integers can be improved in a similar fashion as the same computation for longs. This has some performance benefits, since for large roots (say, 100) this reduces the number of necessary iterations to one-hundredth of the original number.

This optimisation in turn has the benefit of improving the speed of the fpow computation for reals, since these use big integer roots internally. For instance, computing the 1000th root of 1.5 takes 137000 iterations in the current implementation, but can be improved to only 137 iterations.

The commits handle this improvement and add a test that checks that the discrete root of big integers satisfies the desired properties.