### PR TITLE
Fix typos

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -16,7 +16,7 @@ This is achieved by having two cases: `SafeLongLong(x: Long)` is used for number
 
 ### Implementation notes
 
-Operations of `SafeLongBigInt` use the underyling BigInt and create the appropriate kind of result depending on whether the result is a valid long.
+Operations of `SafeLongBigInt` use the underlying BigInt and create the appropriate kind of result depending on whether the result is a valid long.
 
 Operations on `SafeLongLong` use the Checked macro to perform operations using long integers, and only fall back to using `BigInt` in case of numeric overflow.
 

--- a/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
+++ b/benchmark/src/main/scala/spire/benchmark/ScalaVsSpire.scala
@@ -272,5 +272,5 @@ class ScalaVsSpireBenchmarks {
 //
 //object Scala {
 //  @tailrec final def gcd[A: Integral](a: A, b: A): A =
-//    if (a % b == implicitly[Integra[A]].zero) b else gcd(b, a % b)
+//    if (a % b == implicitly[Integral[A]].zero) b else gcd(b, a % b)
 //}

--- a/core/src/main/scala/spire/math/FastComplex.scala
+++ b/core/src/main/scala/spire/math/FastComplex.scala
@@ -194,7 +194,7 @@ object FastComplex {
     }
   }
 
-  /* TODO: does it make sense? Should match the behvaior on Gaussian integers
+  /* TODO: does it make sense? Should match the behavior on Gaussian integers
    final def quot(a: Long, b: Long): Long =
     encode(Math.floor(real(divide(a, b))).toFloat, 0.0F)
 

--- a/core/src/main/scala/spire/math/Polynomial.scala
+++ b/core/src/main/scala/spire/math/Polynomial.scala
@@ -153,7 +153,7 @@ object Polynomial extends PolynomialInstances {
 trait Polynomial[@sp(Double) C] { lhs =>
   implicit def ct: ClassTag[C]
 
-  /** Returns a polynmial that has a dense representation. */
+  /** Returns a polynomial that has a dense representation. */
   def toDense(implicit ring: Semiring[C], eq: Eq[C]): PolyDense[C]
 
   /** Returns a polynomial that has a sparse representation. */

--- a/core/src/main/scala/spire/math/poly/RootIsolator.scala
+++ b/core/src/main/scala/spire/math/poly/RootIsolator.scala
@@ -8,7 +8,7 @@ import spire.std.bigInt._
 import spire.syntax.std.seq._
 
 /**
- * A type class for retreiving isolated roots.
+ * A type class for retrieving isolated roots.
  */
 sealed trait RootIsolator[A] {
 

--- a/core/src/main/scala/spire/math/prime/FactorHeap.scala
+++ b/core/src/main/scala/spire/math/prime/FactorHeap.scala
@@ -10,7 +10,7 @@ import SieveUtil._
  * more than this many prime factors.
  *
  * Note that "fast factors" don't end up in this heap, so the number
- * of primes we can sieve is actaully the max heap size + the number
+ * of primes we can sieve is actually the max heap size + the number
  * of fast factors.
  *
  * The sieve implementation itself uses a cutoff, so to test primality

--- a/core/src/main/scala/spire/math/prime/SieveUtil.scala
+++ b/core/src/main/scala/spire/math/prime/SieveUtil.scala
@@ -19,7 +19,7 @@ object SieveUtil {
   }
 
   /**
-   * Reprsents a prime factor which we need to keep track of.
+   * Represents a prime factor which we need to keep track of.
    *
    * Similar to Factor, but in this case the prime is small enough that
    * it fits in an Int. This means that each of our sieve segments will

--- a/tests/src/test/scala/spire/math/NumberTest.scala
+++ b/tests/src/test/scala/spire/math/NumberTest.scala
@@ -92,7 +92,7 @@ class NumberTest extends AnyFunSuite {
   test("operations") {
     assert(Number(3) + Number(4) === Number(7))
 
-    // since 30.0 can be repesented as a SafeLong, we get an IntNumber
+    // since 30.0 can be represented as a SafeLong, we get an IntNumber
     assert(Number(4) ** Number(30.0) === Number("1152921504606846976"))
 
     // since 30.5 can't, we get a DoubleNumber

--- a/tests/src/test/scala/spire/math/RealCheck.scala
+++ b/tests/src/test/scala/spire/math/RealCheck.scala
@@ -133,7 +133,7 @@ class RealCheck extends AnyPropSpec with Matchers with ScalaCheckDrivenPropertyC
     }
   }
 
-  // since atan2 has branch cuts, we limit the magnitue of x and y
+  // since atan2 has branch cuts, we limit the magnitude of x and y
   property("sin(atan2(y, x)) = y/mag, cos(atan2(y, x)) = x/mag") {
     forAll { (yn: Long, yd: Long, xn: Long, xd: Long) =>
       if (xd != 0 && yd != 0 && (xn != 0 || yn != 0)) {

--- a/tests/src/test/scala/spire/math/fpf/FPFilterTest.scala
+++ b/tests/src/test/scala/spire/math/fpf/FPFilterTest.scala
@@ -21,7 +21,7 @@ class FpFilterTest extends AnyFunSuite with Checkers {
 
   // This will always error out for any operation. It can be used to ensure
   // operations are always performed with Doubles only and never fall back to
-  // the exact case, since it'll fail with an Evaluated excetion.
+  // the exact case, since it'll fail with an Evaluated exception.
   sealed trait Bad
   implicit object BadField extends Field[Bad] with IsReal[Bad] with NRoot[Bad] {
     def zero: Bad = evaluated


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.