### PR TITLE
Fix badges in Readme

### DIFF
--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -5,9 +5,9 @@ section: "Home"
 position: 0
 ---
 
-[![Build Status](https://api.travis-ci.org/non/spire.png)](https://travis-ci.org/non/spire/)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/non/spire?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![codecov.io](http://codecov.io/github/non/spire/coverage.svg?branch=master)](http://codecov.io/github/non/spire?branch=master)
+[![Build Status](https://api.travis-ci.org/typelevel/spire.png)](https://travis-ci.org/non/spire/)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/typelevel/spire?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![codecov.io](https://codecov.io/github/typelevel/spire/coverage.svg?branch=master)](http://codecov.io/github/typelevel/spire?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.typelevel/spire_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.typelevel/spire_2.11)
 
 ## Spire


### PR DESCRIPTION
Fixes the badges for Travis, Gitter and Codecov.io as they still point to the outdated non/spire repo path