### PR TITLE
bump discipline-scalatest version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val scalaCheckVersion = "1.14.3"
 lazy val scalaTestVersion = "3.2.0-M4"
 lazy val scalaTestPlusVersion = "3.1.0.0-RC2"
 lazy val shapelessVersion = "2.3.3"
-lazy val disciplineScalaTestVersion = "1.0.0-RC1"
+lazy val disciplineScalaTestVersion = "1.0.1"
 lazy val machinistVersion = "0.6.8"
 lazy val algebraVersion = "2.0.0"
 

--- a/tests/src/test/scala/spire/laws/ExtraLawTests.scala
+++ b/tests/src/test/scala/spire/laws/ExtraLawTests.scala
@@ -1,11 +1,12 @@
 package spire.laws
 
 import org.scalatest.funsuite.AnyFunSuite
-import org.typelevel.discipline.scalatest.Discipline
+import org.scalatestplus.scalacheck.Checkers
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import spire.math.extras.interval.{IntervalSeq, IntervalSeqArbitrary} // IntervalTrie, IntervalTrieArbitrary
 import spire.implicits._
 
-class ExtraLawTests extends AnyFunSuite with Discipline {
+class ExtraLawTests extends AnyFunSuite with FunSuiteDiscipline with Checkers {
   import IntervalSeqArbitrary._
   // import IntervalTrieArbitrary._
 

--- a/tests/src/test/scala/spire/laws/LawTests.scala
+++ b/tests/src/test/scala/spire/laws/LawTests.scala
@@ -17,13 +17,14 @@ import spire.implicits.{
   MapEq => _, MapGroup => _,
   _ }
 
-import org.typelevel.discipline.scalatest.Discipline
+import org.scalatestplus.scalacheck.Checkers
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 
-class LawTests extends AnyFunSuite with Discipline {
+class LawTests extends AnyFunSuite with FunSuiteDiscipline with Checkers {
 
   def fuzzyEq[@sp(Float,Double) A: Ring: Signed: Order](eps: A): Eq[A] = new Eq[A] {
     def eqv(x: A, y: A): Boolean = {


### PR DESCRIPTION
having this upgrade merged would be helpful to me in the Scala
community build, where we can only support a single version of
discipline-scalatest (without contortions, anyway)