### PR TITLE
Skip coverage and update scala.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ TAGS
 .history
 .*.swp
 .idea
+project/metals.sbt
+.metals/
+.bloop/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ scala:
   - *scala_version_213
 
 env:
+  - SCALAJS_VERSION=1.1.1
   - SCALAJS_VERSION=0.6.32
-  - SCALAJS_VERSION=1.0.1
 
 jdk:
   - openjdk10
@@ -24,8 +24,8 @@ cache:
 script:
   - scripts/travis-publish.sh
 
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+#after_success:
+  #- bash <(curl -s https://codecov.io/bash)
 
 before_cache:
   - du -h -d 1 $HOME/.ivy2/cache

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,10 @@ import ReleaseTransformations._
 import sbtcrossproject.{CrossType, crossProject}
 val crossScalaVersionsFromTravis = settingKey[Seq[String]]("Scala versions set in .travis.yml as scala_version_XXX")
 
+// This is true if there is SCALAJS_VERSION defined with a value of 0.6
+// If it doesn't exists or starts with 1.0 turns to false
+val customScalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).exists(_.startsWith("0.6"))
+
 crossScalaVersionsFromTravis in Global := {
   val manifest = (baseDirectory in ThisBuild).value / ".travis.yml"
   import collection.JavaConverters._
@@ -318,6 +322,7 @@ lazy val commonJvmSettings = Seq(
     case Some((2, scalaMajor)) if scalaMajor <= 11 => Seq("-optimize")
     case _ => Seq.empty
   }),
+  skip.in(publish) := customScalaJSVersion, // Don't publish the jvm side if sjs 0.6 is in use
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.33")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.1.1")
 
 addSbtPlugin("com.jsuereth"        % "sbt-pgp"               % "2.0.1")
 addSbtPlugin("com.github.gseitz"   % "sbt-release"           % "1.0.13")
@@ -11,7 +11,7 @@ addSbtPlugin("pl.project13.scala"  % "sbt-jmh"               % "0.3.7")
 addSbtPlugin("org.scoverage"       % "sbt-scoverage"         % "1.6.1")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"    % "sbt-git"               % "1.0.0")
-addSbtPlugin("org.xerial.sbt"      % "sbt-sonatype"          % "3.9.2")
+addSbtPlugin("org.xerial.sbt"      % "sbt-sonatype"          % "3.9.4")
 addSbtPlugin("org.scala-js"        % "sbt-scalajs"           % scalaJSVersion)
 addSbtPlugin("org.tpolecat"        % "tut-plugin"            % "0.6.13")
 addSbtPlugin("net.virtual-void"    % "sbt-dependency-graph"  % "0.9.2")

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -13,9 +13,9 @@ scala_js="$sbt_cmd macrosJS/test && $sbt_cmd coreJS/test && $sbt_cmd extrasJS/te
 if [[ "$TRAVIS_SCALA_VERSION" == 2.13* ]]; then
     # tut currently has issues with 2.13
     # see https://github.com/tpolecat/tut/issues/246
-    scala_jvm="$sbt_cmd clean coverage validateJVM coverageReport coverageOff"
+    scala_jvm="$sbt_cmd clean coverage validateJVM"
 else
-    scala_jvm="$sbt_cmd clean coverage validateJVM coverageReport coverageOff docs/tut"
+    scala_jvm="$sbt_cmd clean coverage validateJVM docs/tut"
 fi
 
 run_cmd="$scala_js && $scala_jvm"


### PR DESCRIPTION
This updates seem to make travis happy and includes these updates:

* Update scala.js to 1.1.1 and makes it the default
* Skip coverage check
* Skip publication of the jvm side if scala.js is set to 0.6.x