### PR TITLE
Switch to LazyList

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,8 @@ crossScalaVersionsFromTravis in Global := {
   }
 }
 
+lazy val scalaCollectionCompatVersion = "2.1.6"
+
 lazy val scalaCheckVersion = "1.14.3"
 lazy val scalaTestVersion = "3.2.1"
 lazy val scalaTestPlusVersion = "3.2.1.0"
@@ -296,8 +298,11 @@ lazy val buildSettings = Seq(
   }
 )
 
-lazy val commonDeps = Seq(libraryDependencies ++= Seq(
-  "org.typelevel" %%% "algebra" % algebraVersion)
+lazy val commonDeps = Seq(
+  libraryDependencies ++= Seq(
+    "org.scala-lang.modules" %%% "scala-collection-compat" % scalaCollectionCompatVersion,
+    "org.typelevel" %%% "algebra" % algebraVersion
+  )
 )
 
 lazy val commonSettings = Seq(

--- a/core/src/main/scala/spire/math/poly/SpecialPolynomials.scala
+++ b/core/src/main/scala/spire/math/poly/SpecialPolynomials.scala
@@ -2,17 +2,17 @@ package spire
 package math
 package poly
 
+import scala.collection.compat.immutable.LazyList
 
 import spire.algebra.{Eq, Field, Ring}
-import spire.math.Polynomial
 import spire.syntax.field._
 
 object SpecialPolynomials {
 
-  // Horner scheme polynomial generator stream
+  // Horner scheme polynomial generator lazy list
   def hornerScheme[C: Ring: Eq: ClassTag](zero: Polynomial[C], one: Polynomial[C],
-                   fn: (Polynomial[C], Polynomial[C], Int) => Polynomial[C]): Stream[Polynomial[C]] = {
-    def loop(pnm1: Polynomial[C], pn: Polynomial[C], n: Int = 1): Stream[Polynomial[C]] = {
+                       fn: (Polynomial[C], Polynomial[C], Int) => Polynomial[C]): LazyList[Polynomial[C]] = {
+    def loop(pnm1: Polynomial[C], pn: Polynomial[C], n: Int = 1): LazyList[Polynomial[C]] = {
       pn #:: loop(pn, fn(pn, pnm1, n), n + 1)
     }
     zero #:: loop(zero, one)
@@ -47,26 +47,26 @@ object SpecialPolynomials {
     (pn: Polynomial[C], pnm1: Polynomial[C], n: Int) => Polynomial.twox[C] * pn - pn.derivative
 
   // Legendre polynomials of the first kind
-  def legendres[C: Field: Eq: ClassTag](num: Int): Stream[Polynomial[C]] =
+  def legendres[C: Field: Eq: ClassTag](num: Int): LazyList[Polynomial[C]] =
     hornerScheme(Polynomial.one[C], Polynomial.x[C], legendreFn[C]).take(num)
 
   // Laguerre polynomials
-  def laguerres[C: Eq: ClassTag](num: Int)(implicit f: Field[C]): Stream[Polynomial[C]] =
+  def laguerres[C: Eq: ClassTag](num: Int)(implicit f: Field[C]): LazyList[Polynomial[C]] =
     hornerScheme(Polynomial.one[C], Polynomial(Map((0, f.one), (1, -f.one))), laguerreFn[C]).take(num)
 
   // Chebyshev polynomials of the first kind
-  def chebyshevsFirstKind[C: Ring: Eq: ClassTag](num: Int): Stream[Polynomial[C]] =
+  def chebyshevsFirstKind[C: Ring: Eq: ClassTag](num: Int): LazyList[Polynomial[C]] =
     hornerScheme(Polynomial.one[C], Polynomial.x[C], chebyshevFn[C]).take(num)
 
   // Chebyshev polynomials of the second kind
-  def chebyshevsSecondKind[C: Ring: Eq: ClassTag](num: Int): Stream[Polynomial[C]] =
+  def chebyshevsSecondKind[C: Ring: Eq: ClassTag](num: Int): LazyList[Polynomial[C]] =
     hornerScheme(Polynomial.one[C], Polynomial.twox[C], chebyshevFn[C]).take(num)
 
   // Probability hermite polynomials
-  def probHermites[C: Ring: Eq: ClassTag](num: Int): Stream[Polynomial[C]] =
+  def probHermites[C: Ring: Eq: ClassTag](num: Int): LazyList[Polynomial[C]] =
     hornerScheme(Polynomial.one[C], Polynomial.x[C], hermiteFnProb[C]).take(num)
 
   // Physics hermite polynomials
-  def physHermites[C: Ring: Eq: ClassTag](num: Int): Stream[Polynomial[C]] =
+  def physHermites[C: Ring: Eq: ClassTag](num: Int): LazyList[Polynomial[C]] =
     hornerScheme(Polynomial.one[C], Polynomial.twox[C], hermiteFnPhys[C]).take(num)
 }

--- a/core/src/main/scala/spire/math/prime/Siever.scala
+++ b/core/src/main/scala/spire/math/prime/Siever.scala
@@ -5,8 +5,10 @@ import spire.math.SafeLong
 
 import SieveUtil._
 
+import scala.collection.compat.immutable.LazyList
+
 /**
- * Segmented Stream of Eratosthenes implementation
+ * Segmented Sieve of Eratosthenes implementation
  *
  * This section really needs some good comments.
  *
@@ -117,6 +119,12 @@ case class Siever(chunkSize: Int, cutoff: SafeLong) {
     nn
   }
 
+  def lazyListAfter(p0: SafeLong): LazyList[SafeLong] = {
+    val p = nextAfter(p0)
+    p #:: lazyListAfter(p)
+  }
+
+  @deprecated("prefer LazyList and lazyListAfter instead", "0.17.0")
   def streamAfter(p0: SafeLong): Stream[SafeLong] = {
     val p = nextAfter(p0)
     p #:: streamAfter(p)

--- a/core/src/main/scala/spire/math/prime/package.scala
+++ b/core/src/main/scala/spire/math/prime/package.scala
@@ -6,6 +6,7 @@ import spire.algebra.Sign.Positive
 import spire.syntax.cfor._
 import spire.syntax.nroot._
 
+import scala.collection.compat.immutable.LazyList
 import scala.collection.mutable
 
 /**
@@ -248,9 +249,17 @@ package object prime {
       loop(1, three)
     }
 
+  def lazyList: LazyList[SafeLong] =
+    lazyList(SieveSize, SafeLong(1000000))
+
+  def lazyList(chunkSize: Int, cutoff: SafeLong): LazyList[SafeLong] =
+    two #:: three #:: prime.Siever(chunkSize, cutoff).lazyListAfter(three)
+
+  @deprecated("prefer lazyList instead", "0.17.0")
   def stream: Stream[SafeLong] =
     stream(SieveSize, SafeLong(1000000))
 
+  @deprecated("prefer lazyList instead", "0.17.0")
   def stream(chunkSize: Int, cutoff: SafeLong): Stream[SafeLong] =
     two #:: three #:: prime.Siever(chunkSize, cutoff).streamAfter(three)
 }

--- a/examples/src/main/scala/spire/example/DataSets.scala
+++ b/examples/src/main/scala/spire/example/DataSets.scala
@@ -7,6 +7,7 @@ import spire.implicits._
 
 import spire.scalacompat.{BuilderCompat, Factory, FactoryCompatOps, IterableOnce}
 
+import scala.collection.compat.immutable.LazyList
 import scala.collection.mutable.{ Builder, ListBuffer }
 
 import java.io.{ BufferedReader, InputStreamReader }
@@ -48,7 +49,7 @@ object DataSet {
   }
 
   private def readDataSet(path: String): List[String] = withResource(path) { reader =>
-    Stream.continually(reader.readLine()).takeWhile(_ != null).toList
+    LazyList.continually(reader.readLine()).takeWhile(_ != null).toList
   }
 
   type Output[+K] = (Int, String => K)

--- a/examples/src/main/scala/spire/example/infset.scala
+++ b/examples/src/main/scala/spire/example/infset.scala
@@ -4,14 +4,16 @@ package examples
 import spire.algebra._
 import spire.math.{Natural, UInt}
 
+import scala.collection.compat.immutable.LazyList
+import scala.collection.compat.immutable.LazyList.#::
 import scala.collection.mutable
 
 object SetUtil {
-  def powerStream[A](members: Stream[A]): Stream[Set[A]] = {
-    val done = Stream.empty[Set[A]]
+  def lazyPowers[A](members: LazyList[A]): LazyList[Set[A]] = {
+    val done = LazyList.empty[Set[A]]
 
-    def powerLoop(as: Stream[A], i: Int): Stream[Set[A]] = {
-      def nthLoop(as: Stream[A], i: Int): Stream[Set[A]] = as match {
+    def powerLoop(as: LazyList[A], i: Int): LazyList[Set[A]] = {
+      def nthLoop(as: LazyList[A], i: Int): LazyList[Set[A]] = as match {
         case a #:: tail =>
           if (i == 0) {
             Set(a) #:: done
@@ -75,8 +77,8 @@ case class PureSet[A](f: A => Boolean) extends Function1[A, Boolean] { lhs =>
   def cross[B](rhs: PureSet[B]): PureSet[(A, B)] =
     PureSet[(A, B)](t => lhs.f(t._1) && rhs.f(t._2))
 
-  def power(universe: Stream[A]): Stream[Set[A]] =
-    SetUtil.powerStream(universe.filter(f))
+  def power(universe: LazyList[A]): LazyList[Set[A]] =
+    SetUtil.lazyPowers(universe.filter(f))
 }
 
 object MathSet { self =>
@@ -184,6 +186,6 @@ sealed trait MathSet[A] extends Function1[A, Boolean] { lhs =>
     case (Inf(x), Inf(y)) => Fin(xor(x, y))
   }
 
-  def power(universe: Stream[A]): Stream[Set[A]] =
-    SetUtil.powerStream(universe.filter(this))
+  def power(universe: LazyList[A]): LazyList[Set[A]] =
+    SetUtil.lazyPowers(universe.filter(this))
 }

--- a/examples/src/main/scala/spire/example/simplification.scala
+++ b/examples/src/main/scala/spire/example/simplification.scala
@@ -4,6 +4,7 @@ package example
 import spire.implicits._
 import spire.math._
 
+import scala.collection.compat.immutable.LazyList
 import scala.collection.mutable.Builder
 import spire.scalacompat.BuilderCompat
 
@@ -78,23 +79,23 @@ object Simplification {
   }
 
   /**
-   * Naive prime stream. For each odd number, this method tries
+   * Naive prime lazy list. For each odd number, this method tries
    * dividing by all previous primes <= sqrt(n).
    *
    * There are a lot of ways to improve this. For now it's a toy.
    * It can generate the millionth prime in ~9s on my computer.
    */
-  val primes: Stream[Int] = {
+  val primes: LazyList[Int] = {
     @tailrec
-    def next(n: Int, stream: Stream[Int]): Stream[Int] =
-      if (stream.isEmpty || (stream.head ** 2) > n)
+    def next(n: Int, ll: LazyList[Int]): LazyList[Int] =
+      if (ll.isEmpty || (ll.head ** 2) > n)
         n #:: loop(n + 2, primes)
-      else if (n % stream.head == 0)
+      else if (n % ll.head == 0)
         next(n + 2, primes)
       else
-        next(n, stream.tail)
+        next(n, ll.tail)
 
-    def loop(n: Int, stream: Stream[Int]): Stream[Int] = next(n, stream)
+    def loop(n: Int, ll: LazyList[Int]): LazyList[Int] = next(n, ll)
 
     2 #:: loop(3, primes)
   }

--- a/tests/src/test/scala/spire/math/prime/PrimeTest.scala
+++ b/tests/src/test/scala/spire/math/prime/PrimeTest.scala
@@ -29,6 +29,10 @@ class PrimeTest extends AnyFunSuite {
     assert(fill(2, 2).toSeq == tenPrimes.slice(2, 4))
   }
 
+  test("lazyList") {
+    assert(lazyList.take(10).toSeq == tenPrimes)
+  }
+
   test("stream") {
     assert(stream.take(10).toSeq == tenPrimes)
   }


### PR DESCRIPTION
Add APIs that use `LazyList` instead of `Stream`, and
deprecate `Stream` APIs.

Change examples to use `LazyList` instead of `Stream`.

Does not address `BigStream` implementation in
examples.