### PR TITLE
Remove unary ops parentheses

### DIFF
--- a/core/src/main/scala/spire/algebra/Sign.scala
+++ b/core/src/main/scala/spire/algebra/Sign.scala
@@ -7,7 +7,7 @@ package algebra
 sealed abstract class Sign(val toInt: Int) {
   import Sign._
 
-  def unary_-(): Sign = this match {
+  def unary_- : Sign = this match {
     case Positive => Negative
     case Negative => Positive
     case Zero => Zero

--- a/core/src/main/scala/spire/math/Interval.scala
+++ b/core/src/main/scala/spire/math/Interval.scala
@@ -525,7 +525,7 @@ sealed abstract class Interval[A] extends Serializable { lhs =>
   def -(rhs: A)(implicit ev: AdditiveGroup[A]): Interval[A] =
     this + (-rhs)
 
-  def unary_-()(implicit ev: AdditiveGroup[A]): Interval[A] =
+  def unary_-(implicit ev: AdditiveGroup[A]): Interval[A] =
     this match {
       case Point(v) => Point(-v)
       case Bounded(l, u, f) => Bounded(-u, -l, swapFlags(f))

--- a/core/src/main/scala/spire/math/Jet.scala
+++ b/core/src/main/scala/spire/math/Jet.scala
@@ -219,7 +219,7 @@ final case class Jet[@sp(Float, Double) T](real: T, infinitesimal: Array[T])
     !(this eqv b)
   }
 
-  def unary_-()(implicit f: Field[T], v: VectorSpace[Array[T], T]): Jet[T] = {
+  def unary_-(implicit f: Field[T], v: VectorSpace[Array[T], T]): Jet[T] = {
     new Jet(-real, -infinitesimal)
   }
 

--- a/core/src/main/scala/spire/math/Number.scala
+++ b/core/src/main/scala/spire/math/Number.scala
@@ -71,7 +71,7 @@ sealed trait Number extends ScalaNumericConversions with Serializable {
   def canBeLong: Boolean
   def isExact: Boolean
 
-  def unary_-(): Number
+  def unary_- : Number
 
   def toBigInt: BigInt
   def toBigDecimal: BigDecimal

--- a/core/src/main/scala/spire/math/Polynomial.scala
+++ b/core/src/main/scala/spire/math/Polynomial.scala
@@ -402,7 +402,7 @@ trait Polynomial[@sp(Double) C] { lhs =>
     }
   }
 
-  def unary_-()(implicit ring: Rng[C]): Polynomial[C]
+  def unary_-(implicit ring: Rng[C]): Polynomial[C]
   def +(rhs: Polynomial[C])(implicit ring: Semiring[C], eq: Eq[C]): Polynomial[C]
   def -(rhs: Polynomial[C])(implicit ring: Rng[C], eq: Eq[C]): Polynomial[C] = lhs + (-rhs)
   def *(rhs: Polynomial[C])(implicit ring: Semiring[C], eq: Eq[C]): Polynomial[C]

--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -46,7 +46,7 @@ sealed abstract class Rational extends ScalaNumber with ScalaNumericConversions 
   def isZero: Boolean
   def isOne: Boolean
 
-  def unary_-(): Rational
+  def unary_- : Rational
 
   def +(rhs: Rational): Rational
   def -(rhs: Rational): Rational
@@ -454,7 +454,7 @@ object Rational extends RationalInstances {
 
     override def doubleValue: Double = Rational.toDouble(n, d)
 
-    override def unary_-(): Rational =
+    override def unary_- : Rational =
       if (n == Long.MinValue) bigRational(SafeLong.safe64, SafeLong(d))
       else longRational(-n, d)
 
@@ -740,7 +740,7 @@ object Rational extends RationalInstances {
 
     override def doubleValue: Double = Rational.toDouble(n, d)
 
-    override def unary_-(): Rational = Rational(-n, d)
+    override def unary_- : Rational = Rational(-n, d)
 
     def +(r: Rational): Rational = r match {
       case r: LongRational => r + this

--- a/core/src/main/scala/spire/math/Real.scala
+++ b/core/src/main/scala/spire/math/Real.scala
@@ -90,7 +90,7 @@ sealed trait Real extends ScalaNumber with ScalaNumericConversions { x =>
     case _ => x(Real.bits).signum
   }
 
-  def unary_-(): Real = this match {
+  def unary_- : Real = this match {
     case Exact(n) => Exact(-n)
     case _ => Real(p => -x(p))
   }

--- a/core/src/main/scala/spire/math/SafeLong.scala
+++ b/core/src/main/scala/spire/math/SafeLong.scala
@@ -192,7 +192,7 @@ sealed abstract class SafeLong extends ScalaNumber with ScalaNumericConversions 
   def gcd(that: SafeLong): SafeLong
   def lcm(that: SafeLong): SafeLong = if (this.isZero || that.isZero) SafeLong.zero else (this / (this gcd that)) * that
 
-  def unary_-(): SafeLong
+  def unary_- : SafeLong
 
   def isValidLong: Boolean
   def getLong: Opt[Long]
@@ -373,7 +373,7 @@ private[math] final case class SafeLongLong(x: Long) extends SafeLong {
   def |(y: BigInteger): SafeLong = SafeLong(BigInteger.valueOf(x) or y)
   def ^(y: BigInteger): SafeLong = SafeLong(BigInteger.valueOf(x) xor y)
 
-  def unary_-(): SafeLong =
+  def unary_- : SafeLong =
     Checked.tryOrReturn[SafeLong](SafeLongLong(-x))(SafeLongBigInteger(BigInteger.valueOf(x).negate()))
 
   override def <(that: SafeLong): Boolean =
@@ -538,7 +538,7 @@ private[math] final case class SafeLongBigInteger(x: BigInteger) extends SafeLon
   def |(y: BigInteger): SafeLong = SafeLong(x or y)
   def ^(y: BigInteger): SafeLong = SafeLong(x xor y)
 
-  def unary_-(): SafeLong = SafeLong(x.negate())
+  def unary_- : SafeLong = SafeLong(x.negate())
 
   def compare(that: SafeLong): Int =
     that match {

--- a/core/src/main/scala/spire/math/interval/Bound.scala
+++ b/core/src/main/scala/spire/math/interval/Bound.scala
@@ -24,7 +24,7 @@ sealed trait Bound[A] { lhs =>
     case (Open(a), Open(b)) => Open(f(a, b))
   }
 
-  def unary_-()(implicit ev: AdditiveGroup[A]): Bound[A] =
+  def unary_-(implicit ev: AdditiveGroup[A]): Bound[A] =
     lhs.map(-_)
   def reciprocal()(implicit ev: MultiplicativeGroup[A]): Bound[A] =
     lhs.map(_.reciprocal)
@@ -127,7 +127,7 @@ sealed trait ValueBound[A] extends Bound[A] { lhs =>
   def a: A
   def isClosed: Boolean
 
-  override def unary_-()(implicit ev: AdditiveGroup[A]): ValueBound[A] =
+  override def unary_-(implicit ev: AdditiveGroup[A]): ValueBound[A] =
     if (isClosed) Closed(-a) else Open(-a)
 
   override def reciprocal()(implicit ev: MultiplicativeGroup[A]): ValueBound[A] =

--- a/core/src/main/scala/spire/math/poly/PolyDense.scala
+++ b/core/src/main/scala/spire/math/poly/PolyDense.scala
@@ -117,7 +117,7 @@ class PolyDense[@sp(Double) C] private[spire] (val coeffs: Array[C])
     Polynomial.dense(cs)
   }
 
-  def unary_-()(implicit ring: Rng[C]): Polynomial[C] = {
+  def unary_-(implicit ring: Rng[C]): Polynomial[C] = {
     val negArray = new Array[C](coeffs.length)
     cfor(0)(_ < coeffs.length, _ + 1) { i => negArray(i) = -coeffs(i) }
     new PolyDense(negArray)

--- a/core/src/main/scala/spire/math/poly/PolySparse.scala
+++ b/core/src/main/scala/spire/math/poly/PolySparse.scala
@@ -157,7 +157,7 @@ case class PolySparse[@sp(Double) C] private [spire](val exp: Array[Int], val co
     PolySparse.safe(es, cs)
   }
 
-  def unary_-()(implicit ring: Rng[C]): Polynomial[C] = {
+  def unary_-(implicit ring: Rng[C]): Polynomial[C] = {
     val cs = new Array[C](coeff.length)
     cfor(0)(_ < cs.length, _ + 1) { i => cs(i) = -coeff(i) }
     new PolySparse(exp, cs)

--- a/core/src/main/scala/spire/math/prime/Factors.scala
+++ b/core/src/main/scala/spire/math/prime/Factors.scala
@@ -86,7 +86,7 @@ case class Factors(elements: Map[SafeLong, Int], sign: Sign)
       fs.updated(p, fs.getOrElse(p, 0) max e)
     }, Positive)
 
-  def unary_-(): Factors = Factors(elements, -sign)
+  def unary_- : Factors = Factors(elements, -sign)
 
   def +(rhs: Factors): Factors = Factors(lhs.value + rhs.value)
   def +(rhs: SafeLong): Factors = Factors(lhs.value + rhs)

--- a/core/src/main/scala/spire/syntax/Ops.scala
+++ b/core/src/main/scala/spire/syntax/Ops.scala
@@ -201,7 +201,7 @@ final class AdditiveMonoidOps[A](lhs: A)(implicit ev: AdditiveMonoid[A]) {
 }
 
 final class AdditiveGroupOps[A](lhs:A)(implicit ev:AdditiveGroup[A]) {
-  def unary_-(): A = macro Ops.unop[A]
+  def unary_- : A = macro Ops.unop0[A]
   def -(rhs:A): A = macro Ops.binop[A, A]
   def -(rhs:Int)(implicit ev1: Ring[A]): A =  macro Ops.binopWithLift[Int, Ring[A], A]
   def -(rhs:Double)(implicit ev1:Field[A]): A =  macro Ops.binopWithLift[Double, Field[A], A]
@@ -371,7 +371,7 @@ final class JoinOps[A: JoinSemilattice](lhs: A) {
 }
 
 final class HeytingOps[A: Heyting](lhs:A) {
-  def unary_~(): A = macro Ops.unop[A]
+  def unary_~ : A = macro Ops.unop0[A]
   def imp(rhs: A): A = macro Ops.binop[A, A]
 
   def &(rhs: A): A = macro Ops.binop[A, A]
@@ -407,7 +407,7 @@ final class RightModuleOps[V](x: V) {
 final class ModuleUnboundOps[F](lhs: F)(implicit ev: CModule[_, F]) {
   def +(rhs: F): F = macro Ops.binopWithScalar[F, F]
   def -(rhs: F): F = macro Ops.binopWithScalar[F, F]
-  def unary_-(): F = macro Ops.unopWithScalar[F]
+  def unary_- : F = macro Ops.unopWithScalar0[F]
 
   def *(rhs: F): F = macro Ops.binopWithScalar[F, F]
 
@@ -538,7 +538,7 @@ final class ActionUnboundOps[G](lhs: G)(implicit ev: Action[_, G]) {
 final class AdditiveActionUnboundOps[G](lhs: G)(implicit ev: AdditiveAction[_, G]) {
   def +(rhs: G): G = macro Ops.binopWithScalar[G, G]
   def -(rhs: G): G = macro Ops.binopWithScalar[G, G]
-  def unary_-(): G = macro Ops.unopWithScalar[G]
+  def unary_- : G = macro Ops.unopWithScalar0[G]
 }
 
 final class MultiplicativeActionUnboundOps[G](lhs: G)(implicit ev: MultiplicativeAction[_, G]) {


### PR DESCRIPTION
I faced with same problem as https://github.com/typelevel/spire/issues/921. I executed `grep -e 'unary_.()' -r core/` maybe it's enough or not i don't know