### PR TITLE
Type ascriptions

### DIFF
--- a/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/MapSemigroupBenchmarks.scala
@@ -92,7 +92,7 @@ class MapSemigroupBenchmarks extends MyBenchmark with BenchmarkData {
     }
   }
 
-  implicit val semigroup = new Semigroup[Int] {
+  implicit val semigroup: Semigroup[Int] = new Semigroup[Int] {
     def combine(x: Int, y: Int): Int = x + y
   }
 

--- a/core/src/main/scala/spire/algebra/Sign.scala
+++ b/core/src/main/scala/spire/algebra/Sign.scala
@@ -37,7 +37,7 @@ object Sign {
     def compare(x: Sign, y: Sign): Int = java.lang.Integer.signum(x.toInt - y.toInt)
   }
 
-  implicit final val SignAlgebra = new SignAlgebra
+  implicit final val SignAlgebra: CMonoid[Sign] with Signed[Sign] = new SignAlgebra
 
   implicit final val SignMultiplicativeGroup: MultiplicativeCMonoid[Sign] =
     Multiplicative(SignAlgebra)

--- a/core/src/main/scala/spire/math/Algebraic.scala
+++ b/core/src/main/scala/spire/math/Algebraic.scala
@@ -1567,10 +1567,13 @@ object Algebraic extends AlgebraicInstances {
 }
 
 trait AlgebraicInstances {
-  implicit final val AlgebraicAlgebra = new AlgebraicAlgebra
+  implicit final val AlgebraicAlgebra: Field.WithDefaultGCD[Algebraic]
+    with NRoot[Algebraic]
+    with IsAlgebraic[Algebraic]
+    with TruncatedDivisionCRing[Algebraic] = new AlgebraicAlgebra
 
   import NumberTag._
-  implicit final val AlgebraicTag = new LargeTag[Algebraic](Exact, Algebraic(0))
+  implicit final val AlgebraicTag: NumberTag[Algebraic] = new LargeTag[Algebraic](Exact, Algebraic(0))
 }
 
 private[math] trait AlgebraicIsField extends Field.WithDefaultGCD[Algebraic] {

--- a/core/src/main/scala/spire/math/Convertable.scala
+++ b/core/src/main/scala/spire/math/Convertable.scala
@@ -250,19 +250,19 @@ private[math] trait ConvertableToNatural extends ConvertableTo[Natural] {
 object ConvertableTo {
   @inline final def apply[A](implicit ev: ConvertableTo[A]): ConvertableTo[A] = ev
 
-  implicit final val ConvertableToByte = new ConvertableToByte {}
-  implicit final val ConvertableToShort = new ConvertableToShort {}
-  implicit final val ConvertableToInt = new ConvertableToInt {}
-  implicit final val ConvertableToLong = new ConvertableToLong {}
-  implicit final val ConvertableToBigInt = new ConvertableToBigInt {}
-  implicit final val ConvertableToFloat = new ConvertableToFloat {}
-  implicit final val ConvertableToDouble = new ConvertableToDouble {}
-  implicit final val ConvertableToBigDecimal = new ConvertableToBigDecimal {}
-  implicit final val ConvertableToRational = new ConvertableToRational {}
-  implicit final val ConvertableToAlgebraic = new ConvertableToAlgebraic {}
-  implicit final val ConvertableToSafeLong = new ConvertableToSafeLong {}
-  implicit final val ConvertableToNumber = new ConvertableToNumber {}
-  implicit final val ConvertableToNatural = new ConvertableToNatural {}
+  implicit final val ConvertableToByte: ConvertableTo[Byte] = new ConvertableToByte {}
+  implicit final val ConvertableToShort: ConvertableTo[Short] = new ConvertableToShort {}
+  implicit final val ConvertableToInt: ConvertableTo[Int] = new ConvertableToInt {}
+  implicit final val ConvertableToLong: ConvertableTo[Long] = new ConvertableToLong {}
+  implicit final val ConvertableToBigInt: ConvertableTo[BigInt] = new ConvertableToBigInt {}
+  implicit final val ConvertableToFloat: ConvertableTo[Float] = new ConvertableToFloat {}
+  implicit final val ConvertableToDouble: ConvertableTo[Double] = new ConvertableToDouble {}
+  implicit final val ConvertableToBigDecimal: ConvertableTo[BigDecimal] = new ConvertableToBigDecimal {}
+  implicit final val ConvertableToRational: ConvertableTo[Rational] = new ConvertableToRational {}
+  implicit final val ConvertableToAlgebraic: ConvertableTo[Algebraic] = new ConvertableToAlgebraic {}
+  implicit final val ConvertableToSafeLong: ConvertableTo[SafeLong] = new ConvertableToSafeLong {}
+  implicit final val ConvertableToNumber: ConvertableTo[Number] = new ConvertableToNumber {}
+  implicit final val ConvertableToNatural: ConvertableTo[Natural] = new ConvertableToNatural {}
 
   implicit def convertableToComplex[A: Integral]: ConvertableToComplex[A] =
     new ConvertableToComplex[A] { val algebra = Integral[A] }
@@ -547,19 +547,19 @@ private[math] trait ConvertableFromNatural extends ConvertableFrom[Natural] {
 object ConvertableFrom {
   @inline final def apply[A](implicit ev: ConvertableFrom[A]): ConvertableFrom[A] = ev
 
-  implicit final val ConvertableFromByte = new ConvertableFromByte {}
-  implicit final val ConvertableFromShort = new ConvertableFromShort {}
-  implicit final val ConvertableFromInt = new ConvertableFromInt {}
-  implicit final val ConvertableFromLong = new ConvertableFromLong {}
-  implicit final val ConvertableFromFloat = new ConvertableFromFloat {}
-  implicit final val ConvertableFromDouble = new ConvertableFromDouble {}
-  implicit final val ConvertableFromBigInt = new ConvertableFromBigInt {}
-  implicit final val ConvertableFromBigDecimal = new ConvertableFromBigDecimal {}
-  implicit final val ConvertableFromRational = new ConvertableFromRational {}
-  implicit final val ConvertableFromAlgebraic = new ConvertableFromAlgebraic {}
-  implicit final val ConvertableFromSafeLong = new ConvertableFromSafeLong {}
-  implicit final val ConvertableFromNumber = new ConvertableFromNumber {}
-  implicit final val ConvertableFromNatural = new ConvertableFromNatural {}
+  implicit final val ConvertableFromByte: ConvertableFrom[Byte] = new ConvertableFromByte {}
+  implicit final val ConvertableFromShort: ConvertableFrom[Short] = new ConvertableFromShort {}
+  implicit final val ConvertableFromInt: ConvertableFrom[Int] = new ConvertableFromInt {}
+  implicit final val ConvertableFromLong: ConvertableFrom[Long] = new ConvertableFromLong {}
+  implicit final val ConvertableFromFloat: ConvertableFrom[Float] = new ConvertableFromFloat {}
+  implicit final val ConvertableFromDouble: ConvertableFrom[Double] = new ConvertableFromDouble {}
+  implicit final val ConvertableFromBigInt: ConvertableFrom[BigInt] = new ConvertableFromBigInt {}
+  implicit final val ConvertableFromBigDecimal: ConvertableFrom[BigDecimal] = new ConvertableFromBigDecimal {}
+  implicit final val ConvertableFromRational: ConvertableFrom[Rational] = new ConvertableFromRational {}
+  implicit final val ConvertableFromAlgebraic: ConvertableFrom[Algebraic] = new ConvertableFromAlgebraic {}
+  implicit final val ConvertableFromSafeLong: ConvertableFrom[SafeLong] = new ConvertableFromSafeLong {}
+  implicit final val ConvertableFromNumber: ConvertableFrom[Number] = new ConvertableFromNumber {}
+  implicit final val ConvertableFromNatural: ConvertableFrom[Natural] = new ConvertableFromNatural {}
 
   implicit def convertableFromComplex[A: Integral]: ConvertableFromComplex[A] =
     new ConvertableFromComplex[A] { val algebra = Integral[A] }

--- a/core/src/main/scala/spire/math/Fractional.scala
+++ b/core/src/main/scala/spire/math/Fractional.scala
@@ -7,12 +7,12 @@ import spire.std._
 trait Fractional[@sp(Float, Double) A] extends Any with Field[A] with NRoot[A] with Integral[A]
 
 object Fractional {
-  implicit final val FloatIsFractional = new FloatIsFractional
-  implicit final val DoubleIsFractional = new DoubleIsFractional
-  implicit final val BigDecimalIsFractional = new BigDecimalIsFractional
-  implicit final val AlgebraicIsFractional = new AlgebraicIsFractional
-  implicit final val NumberIsFractional = new NumberIsFractional
-  implicit final val RationalIsFractional = new RationalIsFractional
+  implicit final val FloatIsFractional: Fractional[Float] = new FloatIsFractional
+  implicit final val DoubleIsFractional: Fractional[Double] = new DoubleIsFractional
+  implicit final val BigDecimalIsFractional: Fractional[BigDecimal] = new BigDecimalIsFractional
+  implicit final val AlgebraicIsFractional: Fractional[Algebraic] = new AlgebraicIsFractional
+  implicit final val NumberIsFractional: Fractional[Number] = new NumberIsFractional
+  implicit final val RationalIsFractional: Fractional[Rational] = new RationalIsFractional
 
   @inline final def apply[A](implicit ev: Fractional[A]): Fractional[A] = ev
 }

--- a/core/src/main/scala/spire/math/Integral.scala
+++ b/core/src/main/scala/spire/math/Integral.scala
@@ -15,12 +15,12 @@ trait Integral[@sp(Int, Long) A]
     with IsReal[A]
 
 object Integral {
-  implicit final val ByteIsIntegral = new ByteIsIntegral
-  implicit final val ShortIsIntegral = new ShortIsIntegral
-  implicit final val IntIsIntegral = new IntIsIntegral
-  implicit final val LongIsIntegral = new LongIsIntegral
-  implicit final val BigIntIsIntegral = new BigIntIsIntegral
-  implicit final val SafeLongIsIntegral = new SafeLongIsIntegral
+  implicit final val ByteIsIntegral: Integral[Byte] = new ByteIsIntegral
+  implicit final val ShortIsIntegral: Integral[Short] = new ShortIsIntegral
+  implicit final val IntIsIntegral: Integral[Int] = new IntIsIntegral
+  implicit final val LongIsIntegral: Integral[Long] = new LongIsIntegral
+  implicit final val BigIntIsIntegral: Integral[BigInt] = new BigIntIsIntegral
+  implicit final val SafeLongIsIntegral: Integral[SafeLong] = new SafeLongIsIntegral
 
   @inline final def apply[A](implicit ev: Integral[A]): Integral[A] = ev
 }

--- a/core/src/main/scala/spire/math/Natural.scala
+++ b/core/src/main/scala/spire/math/Natural.scala
@@ -714,9 +714,11 @@ object Natural extends NaturalInstances {
 }
 
 trait NaturalInstances {
-  implicit final val NaturalAlgebra = new NaturalAlgebra
+  implicit final val NaturalAlgebra
+    : CRig[Natural] with Order[Natural] with SignedAdditiveCMonoid[Natural] with TruncatedDivision[Natural] =
+    new NaturalAlgebra
   import NumberTag._
-  implicit final val NaturalTag =
+  implicit final val NaturalTag: NumberTag[Natural] =
     new CustomTag[Natural](Integral, Some(Natural.zero), Some(Natural.zero), None, false, false)
 }
 

--- a/core/src/main/scala/spire/math/Number.scala
+++ b/core/src/main/scala/spire/math/Number.scala
@@ -609,7 +609,14 @@ private[math] case class RationalNumber(n: Rational) extends Number { lhs =>
 }
 
 trait NumberInstances {
-  implicit final val NumberAlgebra = new NumberAlgebra
+  implicit final val NumberAlgebra: Field.WithDefaultGCD[Number]
+    with CRing[Number]
+    with NRoot[Number]
+    with Trig[Number]
+    with IsRational[Number]
+    with TruncatedDivisionCRing[Number]
+    with Signed[Number]
+    with Order[Number] = new NumberAlgebra
 }
 
 private[math] trait NumberIsCRing extends CRing[Number] {

--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -859,9 +859,10 @@ object Rational extends RationalInstances {
 }
 
 trait RationalInstances {
-  implicit final val RationalAlgebra = new RationalAlgebra
+  implicit final val RationalAlgebra: Field[Rational] with IsRational[Rational] with TruncatedDivisionCRing[Rational] =
+    new RationalAlgebra
   import NumberTag._
-  implicit final val RationalTag = new LargeTag[Rational](Exact, Rational.zero)
+  implicit final val RationalTag: NumberTag[Rational] = new LargeTag[Rational](Exact, Rational.zero)
 
 }
 

--- a/core/src/main/scala/spire/math/Real.scala
+++ b/core/src/main/scala/spire/math/Real.scala
@@ -575,9 +575,11 @@ object Real extends RealInstances {
 }
 
 trait RealInstances {
-  implicit final val algebra = new RealAlgebra
+  implicit final val algebra
+    : Fractional[Real] with TruncatedDivisionCRing[Real] with Trig[Real] with Field.WithDefaultGCD[Real] =
+    new RealAlgebra
   import NumberTag._
-  implicit final val RealTag = new LargeTag[Real](Exact, Real.zero)
+  implicit final val RealTag: NumberTag[Real] = new LargeTag[Real](Exact, Real.zero)
 }
 
 @SerialVersionUID(0L)

--- a/core/src/main/scala/spire/math/SafeLong.scala
+++ b/core/src/main/scala/spire/math/SafeLong.scala
@@ -622,7 +622,8 @@ trait SafeLongInstances {
   @SerialVersionUID(1L)
   implicit object SafeLongIsReal extends SafeLongIsReal with Serializable
 
-  implicit final val SafeLongTag = new NumberTag.LargeTag[SafeLong](NumberTag.Integral, SafeLong.zero)
+  implicit final val SafeLongTag: NumberTag[SafeLong] =
+    new NumberTag.LargeTag[SafeLong](NumberTag.Integral, SafeLong.zero)
 }
 
 private[math] trait SafeLongIsCRing extends CRing[SafeLong] {

--- a/core/src/main/scala/spire/math/Trilean.scala
+++ b/core/src/main/scala/spire/math/Trilean.scala
@@ -162,9 +162,9 @@ object Trilean {
       case _: Exception => Unknown
     }
 
-  implicit val algebra = new TrileanAlgebra
+  implicit val algebra: DeMorgan[Trilean] = new TrileanAlgebra
 
-  implicit val trileanEq = new Eq[Trilean] {
+  implicit val trileanEq: Eq[Trilean] = new Eq[Trilean] {
     def eqv(x: Trilean, y: Trilean): Boolean = x.value == y.value
   }
 }

--- a/core/src/main/scala/spire/math/UByte.scala
+++ b/core/src/main/scala/spire/math/UByte.scala
@@ -72,10 +72,12 @@ class UByte(val signed: Byte) extends AnyVal with scala.math.ScalaNumericAnyConv
 }
 
 trait UByteInstances {
-  implicit final val UByteAlgebra = new UByteAlgebra
-  implicit final val UByteBitString = new UByteBitString
+  implicit final val UByteAlgebra
+    : CRig[UByte] with IsIntegral[UByte] with TruncatedDivision[UByte] with SignedAdditiveCMonoid[UByte] =
+    new UByteAlgebra
+  implicit final val UByteBitString: BitString[UByte] = new UByteBitString
   import spire.math.NumberTag._
-  implicit final val UByteTag = new UnsignedIntTag[UByte](UByte.MinValue, UByte.MaxValue)
+  implicit final val UByteTag: NumberTag[UByte] = new UnsignedIntTag[UByte](UByte.MinValue, UByte.MaxValue)
 }
 
 private[math] trait UByteIsCRig extends CRig[UByte] {

--- a/core/src/main/scala/spire/math/UInt.scala
+++ b/core/src/main/scala/spire/math/UInt.scala
@@ -62,10 +62,11 @@ class UInt(val signed: Int) extends AnyVal {
 }
 
 trait UIntInstances {
-  implicit final val UIntAlgebra = new UIntAlgebra
-  implicit final val UIntBitString = new UIntBitString
+  implicit final val UIntAlgebra
+    : CRig[UInt] with IsIntegral[UInt] with TruncatedDivision[UInt] with SignedAdditiveCMonoid[UInt] = new UIntAlgebra
+  implicit final val UIntBitString: BitString[UInt] = new UIntBitString
   import spire.math.NumberTag._
-  implicit final val UIntTag = new UnsignedIntTag[UInt](UInt.MinValue, UInt.MaxValue)
+  implicit final val UIntTag: NumberTag[UInt] = new UnsignedIntTag[UInt](UInt.MinValue, UInt.MaxValue)
 }
 
 private[math] trait UIntIsCRig extends CRig[UInt] {

--- a/core/src/main/scala/spire/math/ULong.scala
+++ b/core/src/main/scala/spire/math/ULong.scala
@@ -132,10 +132,12 @@ class ULong(val signed: Long) extends AnyVal {
 }
 
 trait ULongInstances {
-  implicit final val ULongAlgebra = new ULongAlgebra
-  implicit final val ULongBitString = new ULongBitString
+  implicit final val ULongAlgebra
+    : CRig[ULong] with IsIntegral[ULong] with TruncatedDivision[ULong] with SignedAdditiveCMonoid[ULong] =
+    new ULongAlgebra
+  implicit final val ULongBitString: BitString[ULong] = new ULongBitString
   import spire.math.NumberTag._
-  implicit final val ULongTag = new UnsignedIntTag[ULong](ULong.MinValue, ULong.MaxValue)
+  implicit final val ULongTag: NumberTag[ULong] = new UnsignedIntTag[ULong](ULong.MinValue, ULong.MaxValue)
 }
 
 private[math] trait ULongIsCRig extends CRig[ULong] {

--- a/core/src/main/scala/spire/math/UShort.scala
+++ b/core/src/main/scala/spire/math/UShort.scala
@@ -63,10 +63,12 @@ class UShort(val signed: Char) extends AnyVal {
 }
 
 trait UShortInstances {
-  implicit final val UShortAlgebra = new UShortAlgebra
-  implicit final val UShortBitString = new UShortBitString
+  implicit final val UShortAlgebra
+    : CRig[UShort] with IsIntegral[UShort] with TruncatedDivision[UShort] with SignedAdditiveCMonoid[UShort] =
+    new UShortAlgebra
+  implicit final val UShortBitString: BitString[UShort] = new UShortBitString
   import spire.math.NumberTag._
-  implicit final val UShortTag = new UnsignedIntTag[UShort](UShort.MinValue, UShort.MaxValue)
+  implicit final val UShortTag: NumberTag[UShort] = new UnsignedIntTag[UShort](UShort.MinValue, UShort.MaxValue)
 }
 
 private[math] trait UShortIsCRig extends CRig[UShort] {

--- a/core/src/main/scala/spire/optional/rationalTrig.scala
+++ b/core/src/main/scala/spire/optional/rationalTrig.scala
@@ -5,7 +5,7 @@ import spire.algebra.Trig
 import spire.math.Rational
 
 object rationalTrig {
-  implicit val trigRational = new Trig[Rational] {
+  implicit val trigRational: Trig[Rational] = new Trig[Rational] {
     val r180 = Rational(180)
     import spire.std.double._
     def acos(a: Rational): Rational = Rational(spire.math.acos(a.toDouble))

--- a/core/src/main/scala/spire/optional/totalFloat.scala
+++ b/core/src/main/scala/spire/optional/totalFloat.scala
@@ -23,7 +23,7 @@ object totalfloat {
     override def max(x: Float, y: Float): Float = Math.max(x, y)
     def compare(x: Float, y: Float): Int = java.lang.Float.compare(x, y)
   }
-  implicit final val TotalFloatOrder = new TotalFloatOrder {}
+  implicit final val TotalFloatOrder: Order[Float] = new TotalFloatOrder {}
 
   trait TotalDoubleOrder extends Order[Double] {
     override def eqv(x: Double, y: Double): Boolean = java.lang.Double.compare(x, y) == 0
@@ -36,5 +36,5 @@ object totalfloat {
     override def max(x: Double, y: Double): Double = Math.max(x, y)
     def compare(x: Double, y: Double): Int = java.lang.Double.compare(x, y)
   }
-  implicit final val TotalDoubleOrder = new TotalDoubleOrder {}
+  implicit final val TotalDoubleOrder: Order[Double] = new TotalDoubleOrder {}
 }

--- a/core/src/main/scala/spire/random/Generator.scala
+++ b/core/src/main/scala/spire/random/Generator.scala
@@ -519,7 +519,7 @@ trait GeneratorCompanion[G, @sp(Int, Long) S] {
 }
 
 object Generator {
-  implicit val rng = GlobalRng
+  implicit val rng: Generator = GlobalRng
 }
 
 object GlobalRng extends LongBasedGenerator {

--- a/core/src/main/scala/spire/std/bigDecimal.scala
+++ b/core/src/main/scala/spire/std/bigDecimal.scala
@@ -193,10 +193,16 @@ class BigDecimalAlgebra extends BigDecimalIsField with BigDecimalIsNRoot with Bi
 trait BigDecimalInstances {
   import BigDecimal.defaultMathContext
 
-  implicit final val BigDecimalAlgebra = new BigDecimalAlgebra
+  implicit final val BigDecimalAlgebra: Field.WithDefaultGCD[BigDecimal]
+    with NRoot[BigDecimal]
+    with IsRational[BigDecimal]
+    with TruncatedDivisionCRing[BigDecimal]
+    with Signed[BigDecimal]
+    with Order[BigDecimal] = new BigDecimalAlgebra
   implicit def BigDecimalIsTrig(implicit mc: MathContext = defaultMathContext): BigDecimalIsTrig =
     new BigDecimalIsTrig(mc)
 
+  import spire.math.NumberTag
   import spire.math.NumberTag._
-  implicit final val BigDecimalTag = new LargeTag[BigDecimal](Approximate, BigDecimal(0))
+  implicit final val BigDecimalTag: NumberTag[BigDecimal] = new LargeTag[BigDecimal](Approximate, BigDecimal(0))
 }

--- a/core/src/main/scala/spire/std/bigInt.scala
+++ b/core/src/main/scala/spire/std/bigInt.scala
@@ -92,7 +92,14 @@ class BigIntAlgebra
     with Serializable
 
 trait BigIntInstances {
-  implicit final val BigIntAlgebra = new BigIntAlgebra
+  implicit final val BigIntAlgebra: EuclideanRing[BigInt]
+    with NRoot[BigInt]
+    with MetricSpace[BigInt, BigInt]
+    with IsIntegral[BigInt]
+    with TruncatedDivisionCRing[BigInt]
+    with Signed[BigInt]
+    with Order[BigInt] = new BigIntAlgebra
+  import spire.math.NumberTag
   import spire.math.NumberTag._
-  implicit final val BigIntTag = new LargeTag[BigInt](Integral, BigInt(0))
+  implicit final val BigIntTag: NumberTag[BigInt] = new LargeTag[BigInt](Integral, BigInt(0))
 }

--- a/core/src/main/scala/spire/std/bigInteger.scala
+++ b/core/src/main/scala/spire/std/bigInteger.scala
@@ -111,7 +111,14 @@ class BigIntegerAlgebra
     with Serializable
 
 trait BigIntegerInstances {
-  implicit final val BigIntegerAlgebra = new BigIntegerAlgebra
+  implicit final val BigIntegerAlgebra: EuclideanRing[BigInteger]
+    with NRoot[BigInteger]
+    with MetricSpace[BigInteger, BigInteger]
+    with IsIntegral[BigInteger]
+    with TruncatedDivisionCRing[BigInteger]
+    with Signed[BigInteger]
+    with Order[BigInteger] = new BigIntegerAlgebra
+  import spire.math.NumberTag
   import spire.math.NumberTag._
-  implicit final val BigIntegerTag = new LargeTag[BigInteger](Integral, BigInteger.ZERO)
+  implicit final val BigIntegerTag: NumberTag[BigInteger] = new LargeTag[BigInteger](Integral, BigInteger.ZERO)
 }

--- a/core/src/main/scala/spire/std/boolean.scala
+++ b/core/src/main/scala/spire/std/boolean.scala
@@ -46,5 +46,5 @@ class BooleanStructure extends BooleanIsBool with BooleanIsRig with BooleanOrder
 }
 
 trait BooleanInstances {
-  implicit final val BooleanStructure = new BooleanStructure
+  implicit final val BooleanStructure: Bool[Boolean] with CRig[Boolean] with Order[Boolean] = new BooleanStructure
 }

--- a/core/src/main/scala/spire/std/byte.scala
+++ b/core/src/main/scala/spire/std/byte.scala
@@ -109,8 +109,11 @@ class ByteIsBitString extends BitString[Byte] with Serializable {
 class ByteAlgebra extends ByteIsEuclideanRing with ByteIsReal with Serializable
 
 trait ByteInstances {
-  implicit final val ByteBitString = new ByteIsBitString
-  implicit final val ByteAlgebra = new ByteAlgebra
+  implicit final val ByteBitString: BitString[Byte] = new ByteIsBitString
+  implicit final val ByteAlgebra
+    : EuclideanRing[Byte] with IsIntegral[Byte] with TruncatedDivisionCRing[Byte] with Signed[Byte] with Order[Byte] =
+    new ByteAlgebra
+  import spire.math.NumberTag
   import spire.math.NumberTag._
-  implicit final val ByteTag = new BuiltinIntTag[Byte](0, Byte.MinValue, Byte.MaxValue)
+  implicit final val ByteTag: NumberTag[Byte] = new BuiltinIntTag[Byte](0, Byte.MinValue, Byte.MaxValue)
 }

--- a/core/src/main/scala/spire/std/char.scala
+++ b/core/src/main/scala/spire/std/char.scala
@@ -17,5 +17,5 @@ trait CharOrder extends Order[Char] {
 class CharAlgebra extends CharOrder with Serializable
 
 trait CharInstances {
-  implicit final val CharAlgebra = new CharAlgebra
+  implicit final val CharAlgebra: Order[Char] = new CharAlgebra
 }

--- a/core/src/main/scala/spire/std/double.scala
+++ b/core/src/main/scala/spire/std/double.scala
@@ -135,11 +135,19 @@ trait DoubleIsReal extends IsRational[Double] with DoubleTruncatedDivision {
 class DoubleAlgebra extends DoubleIsField with DoubleIsNRoot with DoubleIsTrig with DoubleIsReal with Serializable
 
 trait DoubleInstances {
-  implicit final val DoubleAlgebra = new DoubleAlgebra
+  implicit final val DoubleAlgebra: Field.WithDefaultGCD[Double]
+    with NRoot[Double]
+    with Trig[Double]
+    with IsRational[Double]
+    with TruncatedDivisionCRing[Double]
+    with Signed[Double]
+    with Order[Double] = new DoubleAlgebra
   import Double._
+  import spire.math.NumberTag
   import spire.math.NumberTag._
-  implicit final val DoubleTag = new BuiltinFloatTag(0d, MinValue, MaxValue, NaN, PositiveInfinity, NegativeInfinity) {
-    def isInfinite(a: Double): Boolean = java.lang.Double.isInfinite(a)
-    def isNaN(a: Double): Boolean = java.lang.Double.isNaN(a)
-  }
+  implicit final val DoubleTag: NumberTag[Double] =
+    new BuiltinFloatTag(0d, MinValue, MaxValue, NaN, PositiveInfinity, NegativeInfinity) {
+      def isInfinite(a: Double): Boolean = java.lang.Double.isInfinite(a)
+      def isNaN(a: Double): Boolean = java.lang.Double.isNaN(a)
+    }
 }

--- a/core/src/main/scala/spire/std/float.scala
+++ b/core/src/main/scala/spire/std/float.scala
@@ -139,11 +139,14 @@ trait FloatIsReal extends IsRational[Float] with FloatTruncatedDivision {
 class FloatAlgebra extends FloatIsField with FloatIsNRoot with FloatIsTrig with FloatIsReal with Serializable
 
 trait FloatInstances {
-  implicit final val FloatAlgebra = new FloatAlgebra
+  implicit final val FloatAlgebra
+    : Field.WithDefaultGCD[Float] with NRoot[Float] with Trig[Float] with IsRational[Float] = new FloatAlgebra
   import Float._
+  import spire.math.NumberTag
   import spire.math.NumberTag._
-  implicit final val FloatTag = new BuiltinFloatTag(0f, MinValue, MaxValue, NaN, PositiveInfinity, NegativeInfinity) {
-    def isInfinite(a: Float): Boolean = java.lang.Float.isInfinite(a)
-    def isNaN(a: Float): Boolean = java.lang.Float.isNaN(a)
-  }
+  implicit final val FloatTag: NumberTag[Float] =
+    new BuiltinFloatTag(0f, MinValue, MaxValue, NaN, PositiveInfinity, NegativeInfinity) {
+      def isInfinite(a: Float): Boolean = java.lang.Float.isInfinite(a)
+      def isNaN(a: Float): Boolean = java.lang.Float.isNaN(a)
+    }
 }

--- a/core/src/main/scala/spire/std/int.scala
+++ b/core/src/main/scala/spire/std/int.scala
@@ -105,8 +105,14 @@ class IntIsBitString extends BitString[Int] with Serializable {
 class IntAlgebra extends IntIsEuclideanRing with IntIsNRoot with IntIsReal with Serializable
 
 trait IntInstances {
-  implicit final val IntBitString = new IntIsBitString
-  implicit final val IntAlgebra = new IntAlgebra
+  implicit final val IntBitString: BitString[Int] = new IntIsBitString
+  implicit final val IntAlgebra: EuclideanRing[Int]
+    with NRoot[Int]
+    with IsIntegral[Int]
+    with TruncatedDivisionCRing[Int]
+    with Signed[Int]
+    with Order[Int] = new IntAlgebra
+  import spire.math.NumberTag
   import spire.math.NumberTag._
-  implicit final val IntTag = new BuiltinIntTag[Int](0, Int.MinValue, Int.MaxValue)
+  implicit final val IntTag: NumberTag[Int] = new BuiltinIntTag[Int](0, Int.MinValue, Int.MaxValue)
 }

--- a/core/src/main/scala/spire/std/long.scala
+++ b/core/src/main/scala/spire/std/long.scala
@@ -106,8 +106,14 @@ class LongIsBitString extends BitString[Long] with Serializable {
 class LongAlgebra extends LongIsEuclideanRing with LongIsNRoot with LongIsReal with Serializable
 
 trait LongInstances {
-  implicit final val LongBitString = new LongIsBitString
-  implicit final val LongAlgebra = new LongAlgebra
+  implicit final val LongBitString: BitString[Long] = new LongIsBitString
+  implicit final val LongAlgebra: EuclideanRing[Long]
+    with NRoot[Long]
+    with IsIntegral[Long]
+    with TruncatedDivisionCRing[Long]
+    with Signed[Long]
+    with Order[Long] = new LongAlgebra
+  import spire.math.NumberTag
   import spire.math.NumberTag._
-  implicit final val LongTag = new BuiltinIntTag[Long](0L, Long.MinValue, Long.MaxValue)
+  implicit final val LongTag: NumberTag[Long] = new BuiltinIntTag[Long](0L, Long.MinValue, Long.MaxValue)
 }

--- a/core/src/main/scala/spire/std/short.scala
+++ b/core/src/main/scala/spire/std/short.scala
@@ -109,8 +109,13 @@ class ShortIsBitString extends BitString[Short] with Serializable {
 class ShortAlgebra extends ShortIsEuclideanRing with ShortIsReal with Serializable
 
 trait ShortInstances {
-  implicit final val ShortBitString = new ShortIsBitString
-  implicit final val ShortAlgebra = new ShortAlgebra
+  implicit final val ShortBitString: BitString[Short] = new ShortIsBitString
+  implicit final val ShortAlgebra: EuclideanRing[Short]
+    with IsIntegral[Short]
+    with TruncatedDivisionCRing[Short]
+    with Signed[Short]
+    with Order[Short] = new ShortAlgebra
+  import spire.math.NumberTag
   import spire.math.NumberTag._
-  implicit final val ShortTag = new BuiltinIntTag[Short](0, Short.MinValue, Short.MaxValue)
+  implicit final val ShortTag: NumberTag[Short] = new BuiltinIntTag[Short](0, Short.MinValue, Short.MaxValue)
 }

--- a/core/src/main/scala/spire/std/string.scala
+++ b/core/src/main/scala/spire/std/string.scala
@@ -59,6 +59,6 @@ trait StringInstances0 {
 }
 
 trait StringInstances extends StringInstances0 {
-  implicit final val StringAlgebra = new StringMonoid
-  implicit final val StringOrder = new StringOrder
+  implicit final val StringAlgebra: Monoid[String] = new StringMonoid
+  implicit final val StringOrder: Order[String] = new StringOrder
 }

--- a/core/src/main/scala/spire/std/unit.scala
+++ b/core/src/main/scala/spire/std/unit.scala
@@ -26,5 +26,5 @@ trait UnitAbGroup extends AbGroup[Unit] {
 class UnitAlgebra extends UnitAbGroup with UnitOrder with Serializable
 
 trait UnitInstances {
-  implicit final val UnitAlgebra = new UnitAlgebra
+  implicit final val UnitAlgebra: AbGroup[Unit] with Order[Unit] = new UnitAlgebra
 }

--- a/examples/src/main/scala/spire/example/autoalgebra.scala
+++ b/examples/src/main/scala/spire/example/autoalgebra.scala
@@ -88,16 +88,13 @@ object AutoAlgebraExample extends App {
   implicit val ushortOrder = Auto.scala.order[UShort]
   implicit val ushortRig = Auto.scala.rig[UShort](UShort(0), UShort(1))
 
-  implicit val intOrder = Auto.scala.order[Int]
   implicit val intEuclideanRing = Auto.scala.euclideanRing[Int](0, 1)
 
-  implicit val bigIntOrder = Auto.scala.order[BigInt]
   implicit val bigIntField = Auto.scala.euclideanRing[BigInt](BigInt(0), BigInt(1))
 
   implicit val rationalOrder = Auto.scala.order[Rational]
   implicit val rationalField = Auto.scala.field[Rational](Rational.zero, Rational.one)
 
-  implicit val doubleOrder = Auto.scala.order[Double]
   implicit val doubleField = Auto.scala.field[Double](0d, 1d)
 
   implicit def listMonoid[A] = Auto.scala.collection.monoid[List[A]](Nil)

--- a/examples/src/main/scala/spire/example/bigtrig.scala
+++ b/examples/src/main/scala/spire/example/bigtrig.scala
@@ -127,7 +127,7 @@ object TrigTest {
     println(s"testing $name")
     while (i < limit) {
       if (verbose) println("  trying i=%s".format(i))
-      implicit val mc = new MathContext(i)
+      implicit val mc: MathContext = new MathContext(i)
       val seen = f(mc)
       if (check) {
         val want = BigDecimal(s, mc)

--- a/examples/src/main/scala/spire/example/endoring.scala
+++ b/examples/src/main/scala/spire/example/endoring.scala
@@ -59,7 +59,7 @@ object EndoRingExample extends App {
     def apply[A: AbGroup] = new EndoRing[A]
   }
 
-  implicit val intEndoRing = EndoRing[Int]
+  implicit val intEndoRing: EndoRing[Int] = EndoRing[Int]
 
   // Now we can treat Int => Int functions as a Ring. It obeys all the rules
   // you expect from a Ring, like distributivity. Of course, the
@@ -86,7 +86,7 @@ object EndoRingExample extends App {
     assert(((five * two) + two)(i) == 12 * i)
   }
 
-  implicit val pairedSetEndoRing = EndoRing[(Set[Int], Set[Int])]
+  implicit val pairedSetEndoRing: EndoRing[(Set[Int], Set[Int])] = EndoRing[(Set[Int], Set[Int])]
 
   type PairedSet[A] = (Set[A], Set[A])
 

--- a/examples/src/main/scala/spire/example/kleene.scala
+++ b/examples/src/main/scala/spire/example/kleene.scala
@@ -484,7 +484,7 @@ object KleeneDemo {
    */
   def graphExample(): Unit = {
     // our example graph will be 5x5
-    implicit val dim = Dim(5)
+    implicit val dim: Dim = Dim(5)
 
     // edges for this example
     val edges = List(
@@ -514,7 +514,7 @@ object KleeneDemo {
 
   def pathExample(): Unit = {
     // our example graph will be 5x5
-    implicit val dim = Dim(6)
+    implicit val dim: Dim = Dim(6)
 
     val edges = List(
       (Edge(0, 1), 7),
@@ -581,7 +581,7 @@ object KleeneDemo {
 
   def solvingExample(): Unit = {
     // our example matrix is 2x2
-    implicit val dim = Dim(2)
+    implicit val dim: Dim = Dim(2)
 
     val m: Matrix[Compact[Double]] = ArrayMatrix(Array(2.0, 1.0, 0.0, 2.0)).map(n => Compact(n))
     println("2x2 matrix:\n" + m.show)

--- a/examples/src/main/scala/spire/example/kmeans.scala
+++ b/examples/src/main/scala/spire/example/kmeans.scala
@@ -108,7 +108,7 @@ object KMeansExample extends App {
     bldr.result()
   }
 
-  implicit val mc = java.math.MathContext.DECIMAL128
+  implicit val mc: java.math.MathContext = java.math.MathContext.DECIMAL128
 
   // We construct 3 sets of points, each using different VectorSpaces. We'll
   // cluster each one, using the same k-means algorithm.

--- a/tests/shared/src/test/scala/spire/algebra/PartialOrderSuite.scala
+++ b/tests/shared/src/test/scala/spire/algebra/PartialOrderSuite.scala
@@ -2,9 +2,10 @@ package spire
 package algebra
 
 class PartialOrderSuite extends munit.FunSuite {
+
   import spire.optional.powerSetPartialOrder._
   import spire.implicits._
-  implicit val po = PartialOrder[Set[Int]]
+
   test("Minimal and maximal elements of {{1, 2, 3}, {3}, {2}, {1}} by power set partial order") {
     val sets = Seq(Set(1, 2, 3), Set(3), Set(2), Set(1), Set(1, 4))
     assertEquals(sets.pmin.toSet, Set(Set(1), Set(2), Set(3)))

--- a/tests/shared/src/test/scala/spire/algebra/RingSuite.scala
+++ b/tests/shared/src/test/scala/spire/algebra/RingSuite.scala
@@ -59,7 +59,7 @@ class RingSuite extends munit.FunSuite {
   }
 
   implicit val mc: MathContext = MathContext.DECIMAL128
-  implicit val jetDim = JetDim(7)
+  implicit val jetDim: JetDim = JetDim(7)
 
   // here's where we actually run all the tests, for each type we care about.
   runWith[Int]("Int")(-3, 3, -9)

--- a/tests/shared/src/test/scala/spire/laws/LawSuite.scala
+++ b/tests/shared/src/test/scala/spire/laws/LawSuite.scala
@@ -181,7 +181,7 @@ class LawSuite extends munit.DisciplineSuite {
 
   checkAll("Bool[Boolean]", LogicLaws[Boolean].bool)
   checkAll("Bool[Int]", LogicLaws[Int].bool)
-  implicit val latticeLawsTrilean = _root_.algebra.laws.LatticeLaws[Trilean]
+  implicit val latticeLawsTrilean: _root_.algebra.laws.LatticeLaws[Trilean] = _root_.algebra.laws.LatticeLaws[Trilean]
   checkAll("DeMorgan[Trilean]", DeMorganLaws[Trilean].deMorgan)
 
   object intMinMaxLattice extends MinMaxLattice[Int] with BoundedLattice[Int] with spire.std.IntOrder {

--- a/tests/shared/src/test/scala/spire/math/BinaryMergeScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/BinaryMergeScalaCheckSuite.scala
@@ -3,13 +3,10 @@ package math
 
 import java.util.Arrays
 
-import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 import spire.implicits._
 
 class BinaryMergeScalaCheckSuite extends munit.ScalaCheckSuite {
-
-  implicit val arbitraryArray = implicitly[Arbitrary[Array[Int]]]
 
   property("merge") {
     forAll { (a: Array[Int], b: Array[Int]) =>

--- a/tests/shared/src/test/scala/spire/math/ComplexScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/ComplexScalaCheckSuite.scala
@@ -26,7 +26,7 @@ class ComplexScalaCheckSuite extends munit.ScalaCheckSuite {
       }
     }
 
-  implicit val threshold = BigDecimal(1e-20)
+  implicit val threshold: BigDecimal = BigDecimal(1e-20)
 
   def near(x: Complex[BigDecimal], y: Complex[BigDecimal])(implicit threshold: BigDecimal) =
     if (x == y) x == y else (x - y).abs <= threshold
@@ -49,14 +49,14 @@ class ComplexScalaCheckSuite extends munit.ScalaCheckSuite {
   complex2("(x / y) * y == x") { (x: C, y: C) => if (y != zero) near((x / y) * y, x) }
 
   complex1("x.sqrt.pow(2) = x") { x: C =>
-    implicit val threshold = BigDecimal(2e-9) // 28254913+1i gives a log-error-ratio of 2.02e-9
+    implicit val threshold: BigDecimal = BigDecimal(2e-9) // 28254913+1i gives a log-error-ratio of 2.02e-9
     logNear(x.sqrt.pow(2), x)
   }
 
   // use x*x instead of x.pow(2) because of rounding issues with the latter resulting in some brittleness about whether
   // a subsequent sqrt ends up in the first or fourth quadrants
   complex1("(x*x).sqrt = x") { x: C =>
-    implicit val threshold = BigDecimal(3e-9) // 1+110201870i has log-error-ratio 2.4e-9
+    implicit val threshold: BigDecimal = BigDecimal(3e-9) // 1+110201870i has log-error-ratio 2.4e-9
     // Complex.sqrt returns the root with non-negative real value (and +i in the case of -1); adjust the "expected" RHS
     // accordingly
     if (x.real.signum < 0 || (x.real.signum == 0 && x.imag.signum < 0))

--- a/tests/shared/src/test/scala/spire/math/JetSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/JetSuite.scala
@@ -8,7 +8,7 @@ import java.util.Arrays
 class JetSuite extends munit.FunSuite {
 
   // Default test with 3-dimensional Jet's
-  implicit val dim = JetDim(3)
+  implicit val dim: JetDim = JetDim(3)
   val maxError = 1.0e-12
 
   test("JetDim") {

--- a/tests/shared/src/test/scala/spire/math/PolynomialSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/PolynomialSuite.scala
@@ -13,7 +13,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import java.util.Arrays
 
 object PolynomialSetup {
-  implicit val arbitraryRational = Arbitrary(for {
+  implicit val arbitraryRational: Arbitrary[Rational] = Arbitrary(for {
     n0 <- arbitrary[Long]
     d0 <- arbitrary[Long]
   } yield {
@@ -22,7 +22,7 @@ object PolynomialSetup {
   })
 
   // default scalacheck bigdecimals are weird
-  implicit val arbitraryBigDecimal = Arbitrary(for {
+  implicit val arbitraryBigDecimal: Arbitrary[BigDecimal] = Arbitrary(for {
     r <- arbitrary[Int]
   } yield {
     BigDecimal(r)

--- a/tests/shared/src/test/scala/spire/math/extras/FixedPointScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/extras/FixedPointScalaCheckSuite.scala
@@ -22,7 +22,7 @@ class FixedPointScalaCheckSuite extends munit.ScalaCheckSuite {
 
   property("FixedScale(r).toRational ~= r") {
     forAll { (s: FixedScale, r: Rational) =>
-      implicit val scale = s
+      implicit val scale: FixedScale = s
       val minV = FixedPoint.MinValue.toRational
       val maxV = FixedPoint.MaxValue.toRational
       if (r < minV || maxV < r) {
@@ -35,7 +35,7 @@ class FixedPointScalaCheckSuite extends munit.ScalaCheckSuite {
 
   property("new FixedScale(n).toRational = n/d") {
     forAll { (s: FixedScale, n: Long) =>
-      implicit val scale = s
+      implicit val scale: FixedScale = s
       new FixedPoint(n).toRational == Rational(n, s.denom)
     }
   }
@@ -56,7 +56,7 @@ class FixedPointScalaCheckSuite extends munit.ScalaCheckSuite {
   def testBinop2(name: String, noZero: Boolean, f: S2[FixedPoint], g: F2[Rational]) =
     property(name) {
       forAll { (x: Long, y: Long, s: FixedScale) =>
-        implicit val scale = s
+        implicit val scale: FixedScale = s
         (!noZero || y != 0L) ==> {
           val (fx, fy) = (new FixedPoint(x), new FixedPoint(y))
           val (ax, ay) = (Rational(x, s.denom), Rational(y, s.denom))
@@ -79,7 +79,7 @@ class FixedPointScalaCheckSuite extends munit.ScalaCheckSuite {
 
         val ofz =
           try {
-            implicit val scale = FixedScale(denom)
+            implicit val scale: FixedScale = FixedScale(denom)
             Some(f(fx, fy, scale))
           } catch {
             case _: FixedPointOverflow => None
@@ -102,8 +102,6 @@ class FixedPointScalaCheckSuite extends munit.ScalaCheckSuite {
 
   testBinop2("division", true, (x, y, s) => x./(y)(s), _ / _)
 
-  // testBinop2("modulus", true, (x, y, s) => x % y, _ % _) // TODO: maybe test truncated division instead
-
   def buildHalf(x: Long, z: Byte): (Int, Int, FixedPoint, Rational) = {
     val d = z.toInt.abs % 11
     val denom = 10 ** d
@@ -124,7 +122,7 @@ class FixedPointScalaCheckSuite extends munit.ScalaCheckSuite {
 
         val ofz =
           try {
-            implicit val scale = FixedScale(denom)
+            implicit val scale: FixedScale = FixedScale(denom)
             Some(f(fx, y, scale))
           } catch {
             case _: FixedPointOverflow => None
@@ -147,8 +145,6 @@ class FixedPointScalaCheckSuite extends munit.ScalaCheckSuite {
 
   testHalfop("h-division", true, (x, y, s) => x / y, _ / _)
 
-  //  testHalfop("h-modulus", true, (x, y, s) => (x).%(y)(s), _ % _) // TODO: maybe test truncated division instead
-
   property("pow") {
     forAll { (x: Long, k0: Byte, d0: Byte) =>
       val k = k0.toInt.abs
@@ -158,7 +154,7 @@ class FixedPointScalaCheckSuite extends munit.ScalaCheckSuite {
 
       val ofz =
         try {
-          implicit val scale = FixedScale(denom)
+          implicit val scale: FixedScale = FixedScale(denom)
           Some(new FixedPoint(x).pow(k))
         } catch {
           case _: FixedPointOverflow => None

--- a/tests/shared/src/test/scala/spire/math/extras/interval/IntervalSeqArbitrary.scala
+++ b/tests/shared/src/test/scala/spire/math/extras/interval/IntervalSeqArbitrary.scala
@@ -35,5 +35,5 @@ object IntervalSeqArbitrary {
     15 -> randomProfileXor(Int.MinValue, Int.MaxValue, size)
   )
 
-  implicit val arbIntervalSeq = Arbitrary[IntervalSeq[Int]](randomProfileGen(3))
+  implicit val arbIntervalSeq: Arbitrary[IntervalSeq[Int]] = Arbitrary[IntervalSeq[Int]](randomProfileGen(3))
 }

--- a/tests/shared/src/test/scala/spire/math/extras/interval/IntervalTrieArbitrary.scala
+++ b/tests/shared/src/test/scala/spire/math/extras/interval/IntervalTrieArbitrary.scala
@@ -29,5 +29,5 @@ object IntervalTrieArbitrary {
     15 -> randomProfileXor(Long.MinValue, Long.MaxValue, size)
   )
 
-  implicit val arbIntervalTrie = Arbitrary[IntervalTrie[Long]](randomProfileGen(3))
+  implicit val arbIntervalTrie: Arbitrary[IntervalTrie[Long]] = Arbitrary[IntervalTrie[Long]](randomProfileGen(3))
 }


### PR DESCRIPTION
This PR is towards scala 3 support. Scala 3 require `implicit` to have an explicit type ascription and this is included in this PR