### PR TITLE
use blackhole to improve benchmark

### DIFF
--- a/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
@@ -30,124 +30,122 @@ import org.openjdk.jmh.infra.Blackhole
 @State(Scope.Thread)
 class AddBenchmarks {
 
-
-  def addGeneric[@sp(Int, Long, Float, Double) A: Ring](data: Array[A],bh:Blackhole):Unit = {
+  def addGeneric[@sp(Int, Long, Float, Double) A: Ring](data: Array[A], bh: Blackhole): Unit = {
     var total = Ring[A].zero
     var i = 0
     val len = data.length
     while (i < len) {
-      bh.consume({total = Ring[A].plus(total, data(i))})
+      bh.consume { total = Ring[A].plus(total, data(i)) }
       i += 1
     }
   }
 
-  def addFastComplex(data: Array[Long],bh:Blackhole): Unit = {
+  def addFastComplex(data: Array[Long], bh: Blackhole): Unit = {
     var total = FastComplex(0.0f, 0.0f)
     var i = 0
     val len = data.length
-    while (i < len) { 
-      bh.consume({total = FastComplex.add(total, data(i))})
-      i+=1
+    while (i < len) {
+      bh.consume { total = FastComplex.add(total, data(i)) }
+      i += 1
     }
   }
 
   @Benchmark
-  def addIntDirect(state: IntState,bh:Blackhole): Unit = {
+  def addIntDirect(state: IntState, bh: Blackhole): Unit = {
     val data = state.values
     var total = 0
     var i = 0
     val len = data.length
-    while (i < len) { 
-      bh.consume({total += data(i)})
+    while (i < len) {
+      bh.consume { total += data(i) }
       i += 1
     }
   }
   @Benchmark
-  def addIntGeneric(state: IntState,bh:Blackhole): Unit = addGeneric(state.values,bh)
+  def addIntGeneric(state: IntState, bh: Blackhole): Unit = addGeneric(state.values, bh)
 
   @Benchmark
-  def addLongDirect(state: LongState,bh:Blackhole): Unit = {
+  def addLongDirect(state: LongState, bh: Blackhole): Unit = {
     val data = state.values
     var total = 0L
     var i = 0
     val len = data.length
     while (i < len) {
-      bh.consume({total += data(i)})
-      i += 1 
+      bh.consume { total += data(i) }
+      i += 1
     }
   }
   @Benchmark
-  def addLongGeneric(state: LongState,bh:Blackhole): Unit = addGeneric(state.values,bh)
+  def addLongGeneric(state: LongState, bh: Blackhole): Unit = addGeneric(state.values, bh)
 
   @Benchmark
-  def addFloatDirect(state: FloatState,bh:Blackhole): Float = {
+  def addFloatDirect(state: FloatState, bh: Blackhole): Float = {
     val data = state.values
     var total = 0.0f
     var i = 0
     val len = data.length
-    while (i < len) { bh.consume({total += data(i)}); i += 1 }
+    while (i < len) { bh.consume { total += data(i) }; i += 1 }
     total
 
   }
   @Benchmark
-  def addFloatGeneric(state: FloatState,bh:Blackhole): Unit = addGeneric(state.values,bh)
+  def addFloatGeneric(state: FloatState, bh: Blackhole): Unit = addGeneric(state.values, bh)
 
   @Benchmark
-  def addDoubleDirect(state: DoubleState,bh:Blackhole): Double = {
+  def addDoubleDirect(state: DoubleState, bh: Blackhole): Double = {
     val data = state.values
     var total = 0.0
     var i = 0
     val len = data.length
-    while (i < len) { bh.consume({total += data(i)})  ; i += 1 }
+    while (i < len) { bh.consume { total += data(i) }; i += 1 }
     total
   }
   @Benchmark
-  def addDoublesGeneric(state: DoubleState,bh:Blackhole): Unit = addGeneric(state.values,bh)
+  def addDoublesGeneric(state: DoubleState, bh: Blackhole): Unit = addGeneric(state.values, bh)
 
   @Benchmark
-  def addComplexFloatStateDirect(state: ComplexFloatState,bh:Blackhole): Complex[Float] = {
+  def addComplexFloatStateDirect(state: ComplexFloatState, bh: Blackhole): Complex[Float] = {
     val data = state.values
     var total = Complex.zero[Float]
     var i = 0
     val len = data.length
-    while (i < len) { bh.consume({total += data(i)}); i += 1 }
+    while (i < len) { bh.consume { total += data(i) }; i += 1 }
     total
   }
 
   @Benchmark
-  def addComplexFloatStateGeneric(state: ComplexFloatState,bh:Blackhole): Unit = addGeneric(state.values,bh)
+  def addComplexFloatStateGeneric(state: ComplexFloatState, bh: Blackhole): Unit = addGeneric(state.values, bh)
 
-  
   @Benchmark
-  def addComplexesDirect(state: ComplexFloatState,bh:Blackhole):Complex[Float] = {
+  def addComplexesDirect(state: ComplexFloatState, bh: Blackhole): Complex[Float] = {
     var total = Complex.zero[Float]
     var i = 0
     val len = state.values.length
-    while (i < len) { bh.consume({total += state.values(i)}); i += 1 }
+    while (i < len) { bh.consume { total += state.values(i) }; i += 1 }
     total
   }
 
   @Benchmark
-  def addFastComplexDirect(state: FastComplexState,bh:Blackhole): Long = {
+  def addFastComplexDirect(state: FastComplexState, bh: Blackhole): Long = {
     val data = state.values
     var total = FastComplex(0.0f, 0.0f)
     var i = 0
     val len = data.length
-    while (i < len) { bh.consume({total = FastComplex.add(total, data(i))}); i += 1 }
+    while (i < len) { bh.consume { total = FastComplex.add(total, data(i)) }; i += 1 }
     total
   }
 
   @Benchmark
-  def addComplexDoubleStateDirect(state: ComplexDoubleState,bh:Blackhole): Complex[Double] = {
+  def addComplexDoubleStateDirect(state: ComplexDoubleState, bh: Blackhole): Complex[Double] = {
     val data = state.values
     var total = Complex.zero[Double]
     var i = 0
     val len = data.length
-    while (i < len) { bh.consume({total += data(i)}); i += 1 }
+    while (i < len) { bh.consume { total += data(i) }; i += 1 }
     total
   }
 
   @Benchmark
-  def addComplexDoubleStateGeneric(state: ComplexDoubleState,bh:Blackhole): Unit = addGeneric(state.values,bh)
+  def addComplexDoubleStateGeneric(state: ComplexDoubleState, bh: Blackhole): Unit = addGeneric(state.values, bh)
 
 }

--- a/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
+++ b/benchmark/src/main/scala/spire/benchmark/AddBenchmarks.scala
@@ -23,109 +23,131 @@ import spire.algebra._
 import spire.benchmark.Arrays._
 import spire.implicits._
 import spire.math._
+import org.openjdk.jmh.infra.Blackhole
 
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
 class AddBenchmarks {
 
-  def addGeneric[@sp(Int, Long, Float, Double) A: Ring](data: Array[A]): A = {
+
+  def addGeneric[@sp(Int, Long, Float, Double) A: Ring](data: Array[A],bh:Blackhole):Unit = {
     var total = Ring[A].zero
     var i = 0
     val len = data.length
-    while (i < len) { total = Ring[A].plus(total, data(i)); i += 1 }
-    total
+    while (i < len) {
+      bh.consume({total = Ring[A].plus(total, data(i))})
+      i += 1
+    }
   }
 
-  def addFastComplex(data: Array[Long]): Long = {
+  def addFastComplex(data: Array[Long],bh:Blackhole): Unit = {
     var total = FastComplex(0.0f, 0.0f)
     var i = 0
     val len = data.length
-    while (i < len) { total = FastComplex.add(total, data(i)); i += 1 }
-    total
+    while (i < len) { 
+      bh.consume({total = FastComplex.add(total, data(i))})
+      i+=1
+    }
   }
 
   @Benchmark
-  def addIntDirect(state: IntState): Int = {
+  def addIntDirect(state: IntState,bh:Blackhole): Unit = {
     val data = state.values
     var total = 0
     var i = 0
     val len = data.length
-    while (i < len) { total += data(i); i += 1 }
-    total
+    while (i < len) { 
+      bh.consume({total += data(i)})
+      i += 1
+    }
   }
   @Benchmark
-  def addIntGeneric(state: IntState): Int = addGeneric(state.values)
+  def addIntGeneric(state: IntState,bh:Blackhole): Unit = addGeneric(state.values,bh)
 
   @Benchmark
-  def addLongDirect(state: LongState): Long = {
+  def addLongDirect(state: LongState,bh:Blackhole): Unit = {
     val data = state.values
     var total = 0L
     var i = 0
     val len = data.length
-    while (i < len) { total += data(i); i += 1 }
-    total
+    while (i < len) {
+      bh.consume({total += data(i)})
+      i += 1 
+    }
   }
   @Benchmark
-  def addLongGeneric(state: LongState): Long = addGeneric(state.values)
+  def addLongGeneric(state: LongState,bh:Blackhole): Unit = addGeneric(state.values,bh)
 
   @Benchmark
-  def addFloatDirect(state: FloatState): Float = {
+  def addFloatDirect(state: FloatState,bh:Blackhole): Float = {
     val data = state.values
     var total = 0.0f
     var i = 0
     val len = data.length
-    while (i < len) { total += data(i); i += 1 }
+    while (i < len) { bh.consume({total += data(i)}); i += 1 }
     total
 
   }
   @Benchmark
-  def addFloatGeneric(state: FloatState): Float = addGeneric(state.values)
+  def addFloatGeneric(state: FloatState,bh:Blackhole): Unit = addGeneric(state.values,bh)
 
   @Benchmark
-  def addDoubleDirect(state: DoubleState): Double = {
+  def addDoubleDirect(state: DoubleState,bh:Blackhole): Double = {
     val data = state.values
     var total = 0.0
     var i = 0
     val len = data.length
-    while (i < len) { total += data(i); i += 1 }
+    while (i < len) { bh.consume({total += data(i)})  ; i += 1 }
     total
   }
   @Benchmark
-  def addDoublesGeneric(state: DoubleState): Double = addGeneric(state.values)
+  def addDoublesGeneric(state: DoubleState,bh:Blackhole): Unit = addGeneric(state.values,bh)
 
   @Benchmark
-  def addComplexFloatStateDirect(state: ComplexFloatState): Complex[Float] = {
+  def addComplexFloatStateDirect(state: ComplexFloatState,bh:Blackhole): Complex[Float] = {
     val data = state.values
     var total = Complex.zero[Float]
     var i = 0
     val len = data.length
-    while (i < len) { total += data(i); i += 1 }
+    while (i < len) { bh.consume({total += data(i)}); i += 1 }
     total
   }
-  @Benchmark
-  def addComplexFloatStateGeneric(state: ComplexFloatState): Complex[Float] = addGeneric(state.values)
 
   @Benchmark
-  def addFastComplexDirect(state: FastComplexState): Long = {
+  def addComplexFloatStateGeneric(state: ComplexFloatState,bh:Blackhole): Unit = addGeneric(state.values,bh)
+
+  
+  @Benchmark
+  def addComplexesDirect(state: ComplexFloatState,bh:Blackhole):Complex[Float] = {
+    var total = Complex.zero[Float]
+    var i = 0
+    val len = state.values.length
+    while (i < len) { bh.consume({total += state.values(i)}); i += 1 }
+    total
+  }
+
+  @Benchmark
+  def addFastComplexDirect(state: FastComplexState,bh:Blackhole): Long = {
     val data = state.values
     var total = FastComplex(0.0f, 0.0f)
     var i = 0
     val len = data.length
-    while (i < len) { total = FastComplex.add(total, data(i)); i += 1 }
+    while (i < len) { bh.consume({total = FastComplex.add(total, data(i))}); i += 1 }
     total
   }
 
   @Benchmark
-  def addComplexDoubleStateDirect(state: ComplexDoubleState): Complex[Double] = {
+  def addComplexDoubleStateDirect(state: ComplexDoubleState,bh:Blackhole): Complex[Double] = {
     val data = state.values
     var total = Complex.zero[Double]
     var i = 0
     val len = data.length
-    while (i < len) { total += data(i); i += 1 }
+    while (i < len) { bh.consume({total += data(i)}); i += 1 }
     total
   }
 
   @Benchmark
-  def addComplexDoubleStateGeneric(state: ComplexDoubleState): Complex[Double] = addGeneric(state.values)
+  def addComplexDoubleStateGeneric(state: ComplexDoubleState,bh:Blackhole): Unit = addGeneric(state.values,bh)
 
 }


### PR DESCRIPTION
accumulating result into a local variable suffers from software
pipelining as mentioned in Jmh example about looping. See https://github.com/openjdk/jmh/blob/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_34_SafeLooping.java

In short, this benchmark does not produce proper result.

```java
    @Benchmark
    public int measureWrong_2() {
        int acc = 0;
        for (int x : xs) {
            acc += work(x);
        }
        return acc;
    }
```

You should use Blackhole to avoid compiler optimization. Blackhole
forces runtime to compute every `work()` call in full.

```java
    @Benchmark
    public void measureRight_1(Blackhole bh) {
        for (int x : xs) {
            bh.consume(work(x));
        }
    }
```