### PR TITLE
Add `allButCats` syntax

### DIFF
--- a/core/src/main/scala-2/spire/syntax/Syntax.scala
+++ b/core/src/main/scala-2/spire/syntax/Syntax.scala
@@ -295,12 +295,9 @@ trait LiteralsSyntax {
   object eu { implicit def euLiterals(s: StringContext): EuLiterals = new EuLiterals(s) }
 }
 
-trait AllSyntax
+trait AllButCatsSyntax
     extends LiteralsSyntax
     with CforSyntax
-    with EqSyntax
-    with PartialOrderSyntax
-    with OrderSyntax
     with SignedSyntax
     with TruncatedDivisionSyntax
     with InvolutionSyntax
@@ -308,9 +305,6 @@ trait AllSyntax
     with ConvertableFromSyntax
     with SemigroupoidSyntax
     with GroupoidSyntax
-    with SemigroupSyntax
-    with MonoidSyntax
-    with GroupSyntax
     with AdditiveSemigroupSyntax
     with AdditiveMonoidSyntax
     with AdditiveGroupSyntax
@@ -351,3 +345,12 @@ trait AllSyntax
     with BigIntSyntax
     with ArraySyntax
     with SeqSyntax
+
+trait AllSyntax
+    extends AllButCatsSyntax
+    with EqSyntax
+    with PartialOrderSyntax
+    with OrderSyntax
+    with SemigroupSyntax
+    with MonoidSyntax
+    with GroupSyntax

--- a/core/src/main/scala-3/spire/syntax/Syntax.scala
+++ b/core/src/main/scala-3/spire/syntax/Syntax.scala
@@ -331,12 +331,9 @@ trait LiteralsSyntax {
 
 }
 
-trait AllSyntax
+trait AllButCatsSyntax
     extends LiteralsSyntax
     with CforSyntax
-    with EqSyntax
-    with PartialOrderSyntax
-    with OrderSyntax
     with SignedSyntax
     with TruncatedDivisionSyntax
     with InvolutionSyntax
@@ -344,9 +341,6 @@ trait AllSyntax
     with ConvertableFromSyntax
     with SemigroupoidSyntax
     with GroupoidSyntax
-    with SemigroupSyntax
-    with MonoidSyntax
-    with GroupSyntax
     with AdditiveSemigroupSyntax
     with AdditiveMonoidSyntax
     with AdditiveGroupSyntax
@@ -387,3 +381,12 @@ trait AllSyntax
     with BigIntSyntax
     with ArraySyntax
     with SeqSyntax
+
+trait AllSyntax
+    extends AllButCatsSyntax
+    with EqSyntax
+    with PartialOrderSyntax
+    with OrderSyntax
+    with SemigroupSyntax
+    with MonoidSyntax
+    with GroupSyntax

--- a/core/src/main/scala/spire/syntax/package.scala
+++ b/core/src/main/scala/spire/syntax/package.scala
@@ -79,6 +79,7 @@ package object syntax {
   object numeric extends NumericSyntax
 
   object all extends AllSyntax
+  object allButCats extends AllButCatsSyntax
 
   @deprecated("Unbound syntax will be removed", "spire 0.18.0")
   object unbound extends UnboundSyntax


### PR DESCRIPTION
This will allow:

```
import cats.syntax.all._
import spire.syntax.allButCats._
```

without producing conflicts.