### PR TITLE
Reduce min tests for native in various scalacheck suites

### DIFF
--- a/tests/shared/src/test/scala/spire/math/AlgebraicScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/AlgebraicScalaCheckSuite.scala
@@ -27,6 +27,12 @@ import MathContext.{DECIMAL128, DECIMAL64}
 
 class AlgebraicScalaCheckSuite extends munit.ScalaCheckSuite {
 
+  override def scalaCheckTestParameters =
+    if (sys.props.get("java.vm.name").contains("Scala Native"))
+      // Native is stupidly slow for this suite
+      super.scalaCheckTestParameters.withMinSuccessfulTests(5)
+    else super.scalaCheckTestParameters
+
   def approximation(approx0: Algebraic, scale: Int, actual: BigDecimal): Unit = {
     val error = BigDecimal(10).pow(-scale)
     val approx = approx0.toBigDecimal(scale, RoundingMode.HALF_EVEN)

--- a/tests/shared/src/test/scala/spire/math/PolynomialScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/PolynomialScalaCheckSuite.scala
@@ -32,6 +32,12 @@ import org.scalacheck.Prop
 
 class PolynomialScalaCheckSuite extends munit.ScalaCheckSuite {
 
+  override def scalaCheckTestParameters =
+    if (sys.props.get("java.vm.name").contains("Scala Native"))
+      // Native is stupidly slow for this suite
+      super.scalaCheckTestParameters.withMinSuccessfulTests(5)
+    else super.scalaCheckTestParameters
+
   import PolynomialSetup._
 
   val ebd = Eq[BigDecimal]

--- a/tests/shared/src/test/scala/spire/math/QuaternionScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/QuaternionScalaCheckSuite.scala
@@ -23,6 +23,12 @@ import org.scalacheck.Prop._
 
 class QuaternionScalaCheckSuite extends munit.ScalaCheckSuite {
 
+  override def scalaCheckTestParameters =
+    if (sys.props.get("java.vm.name").contains("Scala Native"))
+      // Native is stupidly slow for this suite
+      super.scalaCheckTestParameters.withMinSuccessfulTests(5)
+    else super.scalaCheckTestParameters
+
   type H = Quaternion[Real]
   val zero = Quaternion.zero[Real]
   val one = Quaternion.one[Real]

--- a/tests/shared/src/test/scala/spire/math/prime/FactorsScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/prime/FactorsScalaCheckSuite.scala
@@ -29,6 +29,12 @@ import org.scalacheck.Prop._
 
 class FactorsScalaCheckSuite extends munit.ScalaCheckSuite {
 
+  override def scalaCheckTestParameters =
+    if (sys.props.get("java.vm.name").contains("Scala Native"))
+      // Native is stupidly slow for this suite
+      super.scalaCheckTestParameters.withMinSuccessfulTests(5)
+    else super.scalaCheckTestParameters
+
   implicit val arbitraryFactors: Arbitrary[Factors] =
     Arbitrary(arbitrary[SafeLong].map(n => Factors(n)))
 


### PR DESCRIPTION
I think this will shave like 10+ minutes off the Native build, which is pretty crazy.