### PR TITLE
Fix `test("capture value in closure")`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.10, 3.2.2]
+        scala: [2.13.10, 3.3.0]
         java: [temurin@8, temurin@11, temurin@17]
         project: [rootJS, rootJVM, rootNative]
         exclude:
-          - scala: 3.2.2
+          - scala: 3.3.0
             java: temurin@11
-          - scala: 3.2.2
+          - scala: 3.3.0
             java: temurin@17
           - project: rootJS
             java: temurin@11
@@ -257,32 +257,32 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.2.2, rootJS)
+      - name: Download target directories (3.3.0, rootJS)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.2-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.0-rootJS
 
-      - name: Inflate target directories (3.2.2, rootJS)
+      - name: Inflate target directories (3.3.0, rootJS)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.2.2, rootJVM)
+      - name: Download target directories (3.3.0, rootJVM)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.2-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.0-rootJVM
 
-      - name: Inflate target directories (3.2.2, rootJVM)
+      - name: Inflate target directories (3.3.0, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.2.2, rootNative)
+      - name: Download target directories (3.3.0, rootNative)
         uses: actions/download-artifact@v3
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.2-rootNative
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.3.0-rootNative
 
-      - name: Inflate target directories (3.2.2, rootNative)
+      - name: Inflate target directories (3.3.0, rootNative)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val jscienceVersion = "4.3.1"
 lazy val apacheCommonsMath3Version = "3.6.1"
 
 val Scala213 = "2.13.10"
-val Scala3 = "3.2.2"
+val Scala3 = "3.3.0"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 

--- a/tests/shared/src/test/scala/spire/syntax/CforSuite.scala
+++ b/tests/shared/src/test/scala/spire/syntax/CforSuite.scala
@@ -104,13 +104,7 @@ class CforSuite extends munit.FunSuite {
     cfor(0)(_ < 3, _ + 1) { x =>
       b1 += (() => x)
     }
-    val b2 = collection.mutable.ArrayBuffer[() => Int]()
-    var i = 0
-    while (i < 3) {
-      b2 += (() => i)
-      i += 1
-    }
-    assertEquals(b1.map(_.apply()).toList, b2.map(_.apply()).toList)
+    assertEquals(b1.map(_.apply()).toList, List(0, 1, 2))
   }
 
   test("capture value in inner class") {


### PR DESCRIPTION
The test broke with the update of scala 3.3.0 (#1225). However the old while loop used in the test as verification did **not** capture the var so always created List(3,3,3). So it tested that the implementation is actually wrong. I changed the test to now use a fixed List.

fixes #1225 