### PR TITLE
enforce new wildcard syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,6 +3,7 @@ runner.dialect = Scala213Source3
 fileOverride {
   "glob:**/scala-3/**" {
     runner.dialect = scala3
+    rewrite.scala3.convertToNewSyntax = false
   }
 }
 align.openParenCallSite = true
@@ -16,3 +17,7 @@ docstrings = JavaDoc
 newlines.afterCurlyLambda = preserve
 docstrings.style = Asterisk
 docstrings.oneline = unfold
+rewrite.scala3.convertToNewSyntax = true
+runner.dialectOverride.allowAsForImportRename = false
+runner.dialectOverride.allowStarWildcardImport = false
+runner.dialectOverride.allowPostfixStarVarargSplices = false

--- a/build.sbt
+++ b/build.sbt
@@ -225,7 +225,7 @@ lazy val unidocSettings = Seq(
   ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(examples, benchmark, tests.jvm)
 )
 
-lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
+lazy val scalaMacroDependencies: Seq[Setting[?]] = Seq(
   libraryDependencies ++= {
     if (scalaVersion.value.startsWith("3")) Seq.empty
     else Seq(scalaOrganization.value % "scala-reflect" % scalaVersion.value % "provided")

--- a/core/src/main/scala-2/spire/math/FpFilter.scala
+++ b/core/src/main/scala-2/spire/math/FpFilter.scala
@@ -60,7 +60,7 @@ final class FpFilter[A](val apx: Double, val mes: Double, val ind: Int, exact0: 
 
   // Avoid using this.
   override def equals(that: Any): Boolean = that match {
-    case that: FpFilter[_] =>
+    case that: FpFilter[?] =>
       if (this.error == 0 && that.error == 0) this.apx == that.apx
       else this.exact == that.exact
     case _ =>

--- a/core/src/main/scala-2/spire/syntax/Ops.scala
+++ b/core/src/main/scala-2/spire/syntax/Ops.scala
@@ -287,7 +287,7 @@ final class RightModuleOps[V](x: V) {
 }
 
 @deprecated("Unbound syntax will be removed", "spire 0.18.0")
-final class ModuleUnboundOps[F: ({ type F[A] = CModule[_, A] })#F](lhs: F) {
+final class ModuleUnboundOps[F: ({ type F[A] = CModule[?, A] })#F](lhs: F) {
   def +(rhs: F): F = macro Ops.binopWithScalar[F, F]
   def -(rhs: F): F = macro Ops.binopWithScalar[F, F]
   def unary_- : F = macro Ops.unopWithScalar0[F]
@@ -309,7 +309,7 @@ final class VectorSpaceOps[V](x: V) {
 }
 
 @deprecated("Unbound syntax will be removed", "spire 0.18.0")
-final class VectorSpaceUnboundOps[F: ({ type F[A] = VectorSpace[_, A] })#F](lhs: F) {
+final class VectorSpaceUnboundOps[F: ({ type F[A] = VectorSpace[?, A] })#F](lhs: F) {
   def /(rhs: F): F = macro Ops.binopWithScalar[F, F]
   def reciprocal: F = macro Ops.unopWithScalar[F]
 }
@@ -414,21 +414,21 @@ final class RightActionOps[P](lhs: P) {
 }
 
 @deprecated("Unbound syntax will be removed", "spire 0.18.0")
-final class ActionUnboundOps[G: ({ type F[A] = Action[_, A] })#F](lhs: G) {
+final class ActionUnboundOps[G: ({ type F[A] = Action[?, A] })#F](lhs: G) {
   def |+|(rhs: G): G = macro Ops.binopWithScalar[G, G]
   def |-|(rhs: G): G = macro Ops.binopWithScalar[G, G]
   def inverse: G = macro Ops.unopWithScalar[G]
 }
 
 @deprecated("Unbound syntax will be removed", "spire 0.18.0")
-final class AdditiveActionUnboundOps[G: ({ type F[A] = AdditiveAction[_, A] })#F](lhs: G) {
+final class AdditiveActionUnboundOps[G: ({ type F[A] = AdditiveAction[?, A] })#F](lhs: G) {
   def +(rhs: G): G = macro Ops.binopWithScalar[G, G]
   def -(rhs: G): G = macro Ops.binopWithScalar[G, G]
   def unary_- : G = macro Ops.unopWithScalar0[G]
 }
 
 @deprecated("Unbound syntax will be removed", "spire 0.18.0")
-final class MultiplicativeActionUnboundOps[G: ({ type F[A] = MultiplicativeAction[_, A] })#F](lhs: G) {
+final class MultiplicativeActionUnboundOps[G: ({ type F[A] = MultiplicativeAction[?, A] })#F](lhs: G) {
   def *(rhs: G): G = macro Ops.binopWithScalar[G, G]
   def /(rhs: G): G = macro Ops.binopWithScalar[G, G]
   def reciprocal: G = macro Ops.unopWithScalar[G]

--- a/core/src/main/scala-2/spire/syntax/Syntax.scala
+++ b/core/src/main/scala-2/spire/syntax/Syntax.scala
@@ -240,18 +240,18 @@ trait IntervalSyntax {
 
 @deprecated("Unbound syntax will be removed", "spire 0.18.0")
 trait UnboundSyntax {
-  implicit def moduleUnboundOps[F](f: F)(implicit ev: CModule[_, F]): ModuleUnboundOps[F] =
+  implicit def moduleUnboundOps[F](f: F)(implicit ev: CModule[?, F]): ModuleUnboundOps[F] =
     new ModuleUnboundOps(f)
 
-  implicit def vectorSpaceUnboundOps[F](f: F)(implicit ev: VectorSpace[_, F]): VectorSpaceUnboundOps[F] =
+  implicit def vectorSpaceUnboundOps[F](f: F)(implicit ev: VectorSpace[?, F]): VectorSpaceUnboundOps[F] =
     new VectorSpaceUnboundOps(f)
 
-  implicit def groupActionUnboundOps[G](g: G)(implicit ev: Action[_, G]): ActionUnboundOps[G] =
+  implicit def groupActionUnboundOps[G](g: G)(implicit ev: Action[?, G]): ActionUnboundOps[G] =
     new ActionUnboundOps(g)
-  implicit def additiveActionUnboundOps[G](g: G)(implicit ev: AdditiveAction[_, G]): AdditiveActionUnboundOps[G] =
+  implicit def additiveActionUnboundOps[G](g: G)(implicit ev: AdditiveAction[?, G]): AdditiveActionUnboundOps[G] =
     new AdditiveActionUnboundOps(g)
   implicit def multiplicativeActionUnboundOps[G](g: G)(implicit
-    ev: MultiplicativeAction[_, G]
+    ev: MultiplicativeAction[?, G]
   ): MultiplicativeActionUnboundOps[G] =
     new MultiplicativeActionUnboundOps(g)
 }

--- a/core/src/main/scala/spire/math/Algebraic.scala
+++ b/core/src/main/scala/spire/math/Algebraic.scala
@@ -167,8 +167,8 @@ final class Algebraic private (val expr: Algebraic.Expr)
     case (that: BigInt)        => isWhole && toBigInt == that
     case (that: Natural)       => isWhole && signum >= 0 && that == toBigInt
     case (that: SafeLong)      => isWhole && that == this
-    case (that: Complex[_])    => that == this
-    case (that: Quaternion[_]) => that == this
+    case (that: Complex[?])    => that == this
+    case (that: Quaternion[?]) => that == this
     case (that: BigDecimal) =>
       try {
         toBigDecimal(that.mc) == that

--- a/core/src/main/scala/spire/math/Complex.scala
+++ b/core/src/main/scala/spire/math/Complex.scala
@@ -352,17 +352,17 @@ final case class Complex[@sp(Float, Double) T](real: T, imag: T)
 
   // not typesafe, so this is the best we can do :(
   override def equals(that: Any): Boolean = that match {
-    case that: Complex[_] => this === that
-    case that: Quaternion[_] =>
+    case that: Complex[?] => this === that
+    case that: Quaternion[?] =>
       real == that.r && imag == that.i && anyIsZero(that.j) && anyIsZero(that.k)
     case that =>
       anyIsZero(imag) && real == that
   }
 
-  def ===(that: Complex[_]): Boolean =
+  def ===(that: Complex[?]): Boolean =
     real == that.real && imag == that.imag
 
-  def =!=(that: Complex[_]): Boolean =
+  def =!=(that: Complex[?]): Boolean =
     !(this === that)
 
   override def toString: String = s"($real + ${imag}i)"

--- a/core/src/main/scala/spire/math/Interval.scala
+++ b/core/src/main/scala/spire/math/Interval.scala
@@ -85,13 +85,13 @@ sealed abstract class Interval[A] extends Serializable { lhs =>
     upper1 > upper2 || upper1 === upper2 && (isClosedUpper(flags1) || isOpenUpper(flags2))
 
   def isEmpty: Boolean =
-    this.isInstanceOf[Empty[_]]
+    this.isInstanceOf[Empty[?]]
 
   def nonEmpty: Boolean =
     !isEmpty
 
   def isPoint: Boolean =
-    this.isInstanceOf[Point[_]]
+    this.isInstanceOf[Point[?]]
 
   def contains(t: A)(implicit o: Order[A]): Boolean =
     hasAtOrBelow(t) && hasAtOrAbove(t)
@@ -187,26 +187,26 @@ sealed abstract class Interval[A] extends Serializable { lhs =>
 
   // Does this interval contains any points at or above t ?
   def hasAtOrAbove(t: A)(implicit o: Order[A]): Boolean = this match {
-    case _: Empty[_] => false
+    case _: Empty[?] => false
     case Point(p)    => p >= t
     case Below(upper, flags) =>
       upper > t || isClosedUpper(flags) && upper === t
     case Bounded(lower, upper, flags) =>
       upper > t || isClosedUpper(flags) && upper === t
-    case _: Above[_] => true
-    case _: All[_]   => true
+    case _: Above[?] => true
+    case _: All[?]   => true
   }
 
   // Does this interval contains any points at or below t ?
   def hasAtOrBelow(t: A)(implicit o: Order[A]): Boolean = this match {
-    case _: Empty[_] => false
+    case _: Empty[?] => false
     case Point(p)    => p <= t
     case Above(lower, flags) =>
       lower < t || isClosedLower(flags) && lower === t
     case Bounded(lower, upper, flags) =>
       lower < t || isClosedLower(flags) && lower === t
-    case _: Below[_] => true
-    case _: All[_]   => true
+    case _: Below[?] => true
+    case _: All[?]   => true
   }
 
   def isAt(t: A)(implicit o: Eq[A]): Boolean = this match {

--- a/core/src/main/scala/spire/math/Jet.scala
+++ b/core/src/main/scala/spire/math/Jet.scala
@@ -507,15 +507,15 @@ final case class Jet[@sp(Float, Double) T](real: T, infinitesimal: Array[T])
   }
 
   override def equals(that: Any): Boolean = that match {
-    case that: Jet[_] => this === that
+    case that: Jet[?] => this === that
     case that         => isReal && real == that
   }
 
-  def ===(that: Jet[_]): Boolean =
+  def ===(that: Jet[?]): Boolean =
     real == that.real && dimension == that.dimension &&
       infinitesimal.zip(that.infinitesimal).forall { case (x, y) => x == y }
 
-  def =!=(that: Jet[_]): Boolean =
+  def =!=(that: Jet[?]): Boolean =
     !(this === that)
 
   override def toString: String = {

--- a/core/src/main/scala/spire/math/Natural.scala
+++ b/core/src/main/scala/spire/math/Natural.scala
@@ -247,8 +247,8 @@ sealed abstract class Natural extends ScalaNumber with ScalaNumericConversions w
     case rhs: Algebraic     => rhs == lhs
     case rhs: Real          => lhs == rhs.toRational
     case rhs: Number        => Number(lhs.toBigInt) == rhs
-    case rhs: Complex[_]    => rhs == lhs
-    case rhs: Quaternion[_] => rhs == lhs
+    case rhs: Complex[?]    => rhs == lhs
+    case rhs: Quaternion[?] => rhs == lhs
     case that               => unifiedPrimitiveEquals(that)
   }
 

--- a/core/src/main/scala/spire/math/Polynomial.scala
+++ b/core/src/main/scala/spire/math/Polynomial.scala
@@ -473,7 +473,7 @@ trait Polynomial[@sp(Double) C] { lhs =>
   }
 
   override def equals(that: Any): Boolean = that match {
-    case rhs: Polynomial[_] if lhs.degree == rhs.degree =>
+    case rhs: Polynomial[?] if lhs.degree == rhs.degree =>
       val it1 = lhs.termsIterator
       val it2 = rhs.termsIterator
       @tailrec def loop(): Boolean = {
@@ -485,7 +485,7 @@ trait Polynomial[@sp(Double) C] { lhs =>
       }
       loop()
 
-    case rhs: Polynomial[_] =>
+    case rhs: Polynomial[?] =>
       false
 
     case n if lhs.isZero =>

--- a/core/src/main/scala/spire/math/Quaternion.scala
+++ b/core/src/main/scala/spire/math/Quaternion.scala
@@ -150,17 +150,17 @@ final case class Quaternion[@sp(Float, Double) A](r: A, i: A, j: A, k: A)
 
   // not typesafe, so this is the best we can do :(
   override def equals(that: Any): Boolean = that match {
-    case that: Quaternion[_] => this === that
-    case that: Complex[_] =>
+    case that: Quaternion[?] => this === that
+    case that: Complex[?] =>
       r == that.real && i == that.imag && anyIsZero(j) && anyIsZero(k)
     case that =>
       sillyIsReal && r == that
   }
 
-  def ===(that: Quaternion[_]): Boolean =
+  def ===(that: Quaternion[?]): Boolean =
     r == that.r && i == that.i && j == that.j && k == that.k
 
-  def =!=(that: Quaternion[_]): Boolean =
+  def =!=(that: Quaternion[?]): Boolean =
     !(this === that)
 
   def isZero(implicit s: Signed[A]): Boolean = r.isSignZero && i.isSignZero && j.isSignZero && k.isSignZero

--- a/core/src/main/scala/spire/math/Rational.scala
+++ b/core/src/main/scala/spire/math/Rational.scala
@@ -282,8 +282,8 @@ sealed abstract class Rational extends ScalaNumber with ScalaNumericConversions 
     case that: SafeLong      => SafeLong(toBigInt) == that
     case that: Number        => Number(this) == that
     case that: Natural       => isWhole && this == Rational(that.toBigInt)
-    case that: Complex[_]    => that == this
-    case that: Quaternion[_] => that == this
+    case that: Complex[?]    => that == this
+    case that: Quaternion[?] => that == this
     case that: Long          => isValidLong && toLong == that
     case that                => unifiedPrimitiveEquals(that)
   }

--- a/core/src/main/scala/spire/math/interval/Overlap.scala
+++ b/core/src/main/scala/spire/math/interval/Overlap.scala
@@ -24,12 +24,12 @@ import spire.syntax.eq._
  * An ADT that represents overlapping result for any two intervals.
  */
 sealed abstract class Overlap[A] extends Product with Serializable {
-  def isDisjoint: Boolean = this.isInstanceOf[Disjoint[_]]
+  def isDisjoint: Boolean = this.isInstanceOf[Disjoint[?]]
   def isSubset: Boolean = this match {
     case Subset(_, _) | Equal() => true
     case _                      => false
   }
-  def isEqual: Boolean = this.isInstanceOf[Equal[_]]
+  def isEqual: Boolean = this.isInstanceOf[Equal[?]]
 }
 
 object Overlap {

--- a/core/src/main/scala/spire/math/poly/PolySparse.scala
+++ b/core/src/main/scala/spire/math/poly/PolySparse.scala
@@ -329,10 +329,10 @@ object PolySparse {
 
   final def apply[@sp(Double) C: Semiring: Eq: ClassTag](poly: Polynomial[C]): PolySparse[C] = {
     poly match {
-      case (poly: PolySparse[_]) =>
+      case (poly: PolySparse[?]) =>
         poly
 
-      case (_: PolyDense[_]) =>
+      case (_: PolyDense[?]) =>
         dense2sparse(poly.asInstanceOf[PolyDense[C]]) // Yay...
 
       case _ =>

--- a/core/src/main/scala/spire/random/Random.scala
+++ b/core/src/main/scala/spire/random/Random.scala
@@ -22,7 +22,7 @@ sealed trait Op[+A] {
 
   def flatMap[B](f: A => Op[B]): Op[B] =
     this match {
-      case fm: FlatMap[a, _] => FlatMap(fm.sub, (x: a) => fm.k(x).flatMap(f))
+      case fm: FlatMap[a, ?] => FlatMap(fm.sub, (x: a) => fm.k(x).flatMap(f))
       case o                 => FlatMap(o, f)
     }
 
@@ -43,7 +43,7 @@ sealed trait Op[+A] {
           case Const(x)          => f(x).resume(gen)
           case More(k)           => Left(() => FlatMap(k(), f))
           case Next(g)           => f(g(gen)).resume(gen)
-          case fm: FlatMap[b, _] => (FlatMap(fm.sub, (x: b) => fm.k(x).flatMap(f)): Op[A]).resume(gen)
+          case fm: FlatMap[b, ?] => (FlatMap(fm.sub, (x: b) => fm.k(x).flatMap(f)): Op[A]).resume(gen)
         }
     }
 

--- a/examples/src/main/scala/spire/example/simplification.scala
+++ b/examples/src/main/scala/spire/example/simplification.scala
@@ -211,7 +211,7 @@ class BigCons[A](override val head: A, t: => BigStream[A]) extends BigStream[A] 
   override def isEmpty = false
   override def toString: String = "BigStream(%s, ...)".format(head.toString)
   override def equals(rhs: Any): Boolean = rhs match {
-    case s: BigStream[_] => !s.isEmpty && tail == s.tail
+    case s: BigStream[?] => !s.isEmpty && tail == s.tail
     case _               => false
   }
 }

--- a/extras/src/main/scala/spire/math/extras/interval/IntervalSeq.scala
+++ b/extras/src/main/scala/spire/math/extras/interval/IntervalSeq.scala
@@ -98,7 +98,7 @@ final class IntervalSeq[T] private (val belowAll: Boolean,
   }
 
   override def equals(rhs: Any): Boolean = rhs match {
-    case rhs: IntervalSeq[_] =>
+    case rhs: IntervalSeq[?] =>
       lhs.belowAll == rhs.belowAll &&
       Arrays.equals(lhs.kinds, rhs.kinds) &&
       Arrays.equals(values.asInstanceOf[Array[AnyRef]], rhs.values.asInstanceOf[Array[AnyRef]])

--- a/extras/src/main/scala/spire/math/extras/interval/IntervalSet.scala
+++ b/extras/src/main/scala/spire/math/extras/interval/IntervalSet.scala
@@ -17,7 +17,7 @@ package spire.math.extras.interval
 
 import spire.math.Interval
 
-abstract class IntervalSet[T, S <: IntervalSet[T, _]] extends (T => Boolean) {
+abstract class IntervalSet[T, S <: IntervalSet[T, ?]] extends (T => Boolean) {
 
   def isEmpty: Boolean
 

--- a/macros/src/main/scala-2/spire/macros/Syntax.scala
+++ b/macros/src/main/scala-2/spire/macros/Syntax.scala
@@ -104,7 +104,7 @@ case class SyntaxUtil[C <: Context with Singleton](val c: C) {
 
   def names(bs: String*) = bs.toList.map(name)
 
-  def isClean(es: c.Expr[_]*): Boolean =
+  def isClean(es: c.Expr[?]*): Boolean =
     es.forall {
       _.tree match {
         case t @ Ident(_: TermName) if t.symbol.asTerm.isStable => true

--- a/tests/shared/src/test/scala/spire/math/IntervalOverlapScalaCheckSuite.scala
+++ b/tests/shared/src/test/scala/spire/math/IntervalOverlapScalaCheckSuite.scala
@@ -54,7 +54,7 @@ class IntervalOverlapScalaCheckSuite extends munit.ScalaCheckSuite {
   property("(-inf, a] overlap [a, +inf) = PartialOverlap") {
     forAll { (x: Rational) =>
       Interval.atOrBelow(x).overlap(Interval.atOrAbove(x)) match {
-        case _: PartialOverlap[_] => true
+        case _: PartialOverlap[?] => true
         case _                    => false
       }
     }
@@ -68,7 +68,7 @@ class IntervalOverlapScalaCheckSuite extends munit.ScalaCheckSuite {
       val sorted = List(x, y, m, n).sorted
       (sorted.distinct == sorted) ==> {
         Interval.openUpper(sorted(0), sorted(2)).overlap(Interval.openLower(sorted(1), sorted(3))) match {
-          case _: PartialOverlap[_] => true
+          case _: PartialOverlap[?] => true
           case _                    => false
         }
       }
@@ -81,7 +81,7 @@ class IntervalOverlapScalaCheckSuite extends munit.ScalaCheckSuite {
       val sorted = List(x, y, m, n).sorted
       (sorted.distinct.size >= 3 && sorted(0) != sorted(1) && sorted(2) != sorted(3)) ==> {
         Interval.closed(sorted(0), sorted(2)).overlap(Interval.closed(sorted(1), sorted(3))) match {
-          case _: PartialOverlap[_] => true
+          case _: PartialOverlap[?] => true
           case _                    => false
         }
       }
@@ -93,7 +93,7 @@ class IntervalOverlapScalaCheckSuite extends munit.ScalaCheckSuite {
       (x != y) ==> {
         import spire.algebra.Order.catsKernelOrderingForOrder
         Interval.below(max(x, y)).overlap(Interval.above(min(x, y))) match {
-          case _: PartialOverlap[_] => true
+          case _: PartialOverlap[?] => true
           case _                    => false
         }
       }
@@ -145,7 +145,7 @@ class IntervalOverlapScalaCheckSuite extends munit.ScalaCheckSuite {
   property("x overlap [a] is never a PartialOverlap") {
     forAll { (x: Interval[Rational], b: Rational) =>
       x.overlap(Interval.point(b)) match {
-        case _: PartialOverlap[_] => false
+        case _: PartialOverlap[?] => false
         case _                    => true
       }
     }

--- a/tests/shared/src/test/scala/spire/random/GeneratorSuite.scala
+++ b/tests/shared/src/test/scala/spire/random/GeneratorSuite.scala
@@ -37,7 +37,7 @@ class GeneratorSuite extends munit.FunSuite {
    * For "real" RNG testing, a suite like DIEHARD is much more appropriate than this file.
    */
 
-  def getName(g: GeneratorCompanion[_, _]): String =
+  def getName(g: GeneratorCompanion[?, ?]): String =
     g.getClass.getSimpleName.replace("$", "")
 
   val size: Int = 10000000


### PR DESCRIPTION
- Scala 3 report warnings since 3.4 https://github.com/lampepfl/dotty/pull/18813
- Scala 2.12 and 2.13 support new syntax without `-Xsource:3` option https://github.com/scala/scala/pull/10005