### PR TITLE
Remove CODE_OF_CONDUCT override, use org default

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,0 @@
-People are expected to follow the [Typelevel Code of Conduct](https://typelevel.org/code-of-conduct.html)
-when discussing Spire on the Github page, in Discord, Gitter, the IRC channel,
-mailing list, and other official venues.
-
-Concerns or issues can be sent to any of Spire's maintainers, or to any of the
-[designated CoC contacts](https://typelevel.org/code-of-conduct.html) for Typelevel.


### PR DESCRIPTION
As per https://github.com/typelevel/governance/issues/133, we're removing the individual CODE_OF_CONDUCT.md files so that org projects use the GitHub Typelevel organization default, which is easier for us to maintain.