### PR TITLE
Update to Scala Native 0.5 and Scala.JS 1.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,12 +14,12 @@ val header = """|***************************************************************
 
 import scala.language.existentials
 
-lazy val scalaCheckVersion = "1.17.0"
+lazy val scalaCheckVersion = "1.18.0"
 
-lazy val munit = "1.0.0-M7"
-lazy val munitDiscipline = "2.0.0-M3"
+lazy val munit = "1.0.0-M11"
+lazy val munitDiscipline = "2.0.0-M4"
 
-lazy val algebraVersion = "2.9.0"
+lazy val algebraVersion = "2.12.0"
 
 lazy val apfloatVersion = "1.10.1"
 lazy val jscienceVersion = "4.3.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ val sbtTypelevelVersion = "0.4.21"
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % sbtTypelevelVersion)
 addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % sbtTypelevelVersion)
 
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.1")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.16")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.5")
 
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")


### PR DESCRIPTION
Update Scala Native without updating Scala due to https://github.com/typelevel/spire/issues/1225

I was able to do some test locally with `sbt test` and `sbt testsNative/test` but Github Actions reported `TASTy signature has wrong version`